### PR TITLE
Allow passing a parser as closuer when a route is matched

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1793,6 +1793,7 @@ name = "spider"
 version = "1.2.1"
 dependencies = [
  "rayon",
+ "regex",
  "reqwest 0.11.0",
  "robotparser",
  "scraper",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ keywords = ["crawler", "spider"]
 categories = ["web-programming"]
 license = "MIT"
 documentation = "https://docs.rs/spider"
+edition = "2018"
 
 [badges]
 maintenance = { status = "as-is" }
@@ -19,3 +20,4 @@ scraper = "0.12"
 robotparser = "0.10"
 url = "2.2"
 rayon = "1.1"
+regex = "1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,3 @@
-extern crate rayon;
-extern crate reqwest;
-extern crate robotparser;
-extern crate scraper;
-extern crate url;
-
 /// Configuration structure for `Website`
 pub mod configuration;
 /// A page scraped


### PR DESCRIPTION
Making this a draft for now until I add more documentation and testing.

This basically adds a method to execute a closure so that we can start parsing pages before the completion of the whole crawl.

Many websites are big enough that crawling will take hours while we need a quick access to crawled data. Also, if anything goes wrong, we lose all the efforts spend.

This PR depends on #9. A rebase might be needed after the former is merged.