### PR TITLE
Compiler Warnings

### DIFF
--- a/spider_cli/src/main.rs
+++ b/spider_cli/src/main.rs
@@ -28,7 +28,7 @@ async fn main() {
     let delay = cli.delay.unwrap_or(website.configuration.delay);
     let user_agent = cli
         .user_agent
-        .unwrap_or(website.configuration.user_agent.to_string());
+        .unwrap_or_else(|| website.configuration.user_agent.to_string());
     let blacklist_url = cli.blacklist_url.unwrap_or_default();
 
     website.configuration.respect_robots_txt = cli.respect_robots_txt;

--- a/spider_cli/src/main.rs
+++ b/spider_cli/src/main.rs
@@ -37,7 +37,7 @@ async fn main() {
     website.configuration.tld = cli.tld;
 
     if !blacklist_url.is_empty() {
-        let blacklist_url: Vec<String> = blacklist_url.split(",").map(|l| l.to_string()).collect();
+        let blacklist_url: Vec<String> = blacklist_url.split(',').map(|l| l.to_string()).collect();
         website.configuration.blacklist_url.extend(blacklist_url);
     }
 


### PR DESCRIPTION
Got 2 compiler warnings (using Rust LSP in Emacs)

1. Usage of unwrap_or followed by a function call. [Fix](https://deepsource.io/directory/analyzers/rust/issues/RS-W1031)

2. delimiter in split was a single character string. Changed to char.