### PR TITLE
Converted clippy warned single character strings to chars

### DIFF
--- a/spider/src/page.rs
+++ b/spider/src/page.rs
@@ -45,7 +45,7 @@ fn build_absolute_selectors(url: &str) -> String {
 /// get the host name for url without tld
 pub fn domain_name(domain: &Url) -> &str {
     let b = domain.host_str().unwrap_or_default();
-    let b = b.split(".").collect::<Vec<&str>>();
+    let b = b.split('.').collect::<Vec<&str>>();
 
     if b.len() > 2 {
         b[1]

--- a/spider/src/website.rs
+++ b/spider/src/website.rs
@@ -50,7 +50,7 @@ type Message = HashSet<String>;
 impl Website {
     /// Initialize Website object with a start link to crawl.
     pub fn new(domain: &str) -> Self {
-        let domain = if domain.ends_with("/") {
+        let domain = if domain.ends_with('/') {
             domain.into()
         } else {
             string_concat!(domain, "/")
@@ -181,7 +181,7 @@ impl Website {
                 let n = &*l.borrow();
                 let (name, rest) = n;
 
-                let url = if name.ends_with("/") {
+                let url = if name.ends_with('/') {
                     name.into()
                 } else {
                     string_concat!(name.clone(), "/")


### PR DESCRIPTION
Converted all explicit clippy warnings of single character strings to chars.