### PR TITLE
perf(crawl): add mass crawl ability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1689,7 +1689,7 @@ dependencies = [
 
 [[package]]
 name = "spider"
-version = "1.19.17"
+version = "1.19.18"
 dependencies = [
  "hashbrown 0.13.2",
  "lazy_static",
@@ -1708,7 +1708,7 @@ dependencies = [
 
 [[package]]
 name = "spider_cli"
-version = "1.19.17"
+version = "1.19.18"
 dependencies = [
  "clap 3.2.23",
  "env_logger",
@@ -1720,7 +1720,7 @@ dependencies = [
 
 [[package]]
 name = "spider_examples"
-version = "1.19.17"
+version = "1.19.18"
 dependencies = [
  "convert_case 0.5.0",
  "env_logger",

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spider_examples"
-version = "1.19.17"
+version = "1.19.18"
 authors = ["madeindjs <contact@rousseau-alexandre.fr>", "j-mendez <jeff@a11ywatch.com>"]
 description = "Multithreaded web crawler written in Rust."
 repository = "https://github.com/spider-rs/spider"
@@ -21,7 +21,7 @@ env_logger = "0.9.0"
 htr = "0.5.23"
 
 [dependencies.spider]
-version = "1.19.17"
+version = "1.19.18"
 path = "../spider"
 default-features = false
 

--- a/spider/Cargo.toml
+++ b/spider/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spider"
-version = "1.19.17"
+version = "1.19.18"
 authors = ["madeindjs <contact@rousseau-alexandre.fr>", "j-mendez <jeff@a11ywatch.com>"]
 description = "Multithreaded web crawler written in Rust."
 repository = "https://github.com/spider-rs/spider"

--- a/spider/README.md
+++ b/spider/README.md
@@ -16,7 +16,7 @@ This is a basic blocking example crawling a web page, add spider to your `Cargo.
 
 ```toml
 [dependencies]
-spider = "1.19.17"
+spider = "1.19.18"
 ```
 
 And then the code:
@@ -62,7 +62,7 @@ There is an optional "regex" crate that can be enabled:
 
 ```toml
 [dependencies]
-spider = { version = "1.19.17", features = ["regex"] }
+spider = { version = "1.19.18", features = ["regex"] }
 ```
 
 ```rust,no_run
@@ -89,7 +89,7 @@ Currently we have three optional feature flags. Regex blacklisting, jemaloc back
 
 ```toml
 [dependencies]
-spider = { version = "1.19.17", features = ["regex", "ua_generator"] }
+spider = { version = "1.19.18", features = ["regex", "ua_generator"] }
 ```
 
 [Jemalloc](https://github.com/jemalloc/jemalloc) performs better for concurrency and allows memory to release easier.
@@ -98,7 +98,7 @@ This changes the global allocator of the program so test accordingly to measure 
 
 ```toml
 [dependencies]
-spider = { version = "1.19.17", features = ["jemalloc"] }
+spider = { version = "1.19.18", features = ["jemalloc"] }
 ```
 
 ## Blocking

--- a/spider_cli/Cargo.toml
+++ b/spider_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spider_cli"
-version = "1.19.17"
+version = "1.19.18"
 authors = ["madeindjs <contact@rousseau-alexandre.fr>", "j-mendez <jeff@a11ywatch.com>"]
 description = "Multithreaded web crawler written in Rust."
 repository = "https://github.com/spider-rs/spider"
@@ -25,7 +25,7 @@ quote = "1.0.18"
 failure_derive = "0.1.8"
 
 [dependencies.spider]
-version = "1.19.17"
+version = "1.19.18"
 path = "../spider"
 
 [[bin]]

--- a/spider_cli/README.md
+++ b/spider_cli/README.md
@@ -34,7 +34,7 @@ spider --domain https://choosealicense.com crawl -o > spider_choosealicense.json
 ```
 
 ```sh
-spider_cli 1.19.17
+spider_cli 1.19.18
 madeindjs <contact@rousseau-alexandre.fr>, j-mendez <jeff@a11ywatch.com>
 Multithreaded web crawler written in Rust.
 

--- a/spider_cli/src/main.rs
+++ b/spider_cli/src/main.rs
@@ -84,7 +84,7 @@ async fn main() {
                 let mut html: &String = &String::new();
 
                 if *output_links {
-                    let page_links = page.links(&*selectors);
+                    let page_links = page.links(&*selectors, &Default::default());
 
                     for link in page_links {
                         links.push(link.as_ref().to_owned());


### PR DESCRIPTION
1. add load balancing IO
2. reduce memory on large scans for message channels


Local mac m1 64gb results.

```
Time elapsed in website.crawl() is: 267.083875s for total pages: 25220
        Command being timed: "./target/release/examples/example"
        User time (seconds): 96.59
        System time (seconds): 14.91
        Percent of CPU this job got: 41%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 4:27.39
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 924272
        Average resident set size (kbytes): 0
        Major (requiring I/O) page faults: 24
        Minor (reclaiming a frame) page faults: 585770
        Voluntary context switches: 4793
        Involuntary context switches: 494010
        Swaps: 0
        File system inputs: 0
        File system outputs: 0
        Socket messages sent: 65379
        Socket messages received: 715743
        Signals delivered: 0
        Page size (bytes): 16384
        Exit status: 0
```