### PR TITLE
perf(client): add mass scan configs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1689,7 +1689,7 @@ dependencies = [
 
 [[package]]
 name = "spider"
-version = "1.19.17"
+version = "1.19.18"
 dependencies = [
  "hashbrown 0.13.2",
  "lazy_static",
@@ -1708,7 +1708,7 @@ dependencies = [
 
 [[package]]
 name = "spider_cli"
-version = "1.19.17"
+version = "1.19.18"
 dependencies = [
  "clap 3.2.23",
  "env_logger",
@@ -1720,7 +1720,7 @@ dependencies = [
 
 [[package]]
 name = "spider_examples"
-version = "1.19.17"
+version = "1.19.18"
 dependencies = [
  "convert_case 0.5.0",
  "env_logger",

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spider_examples"
-version = "1.19.17"
+version = "1.19.18"
 authors = ["madeindjs <contact@rousseau-alexandre.fr>", "j-mendez <jeff@a11ywatch.com>"]
 description = "Multithreaded web crawler written in Rust."
 repository = "https://github.com/spider-rs/spider"
@@ -21,7 +21,7 @@ env_logger = "0.9.0"
 htr = "0.5.23"
 
 [dependencies.spider]
-version = "1.19.17"
+version = "1.19.18"
 path = "../spider"
 default-features = false
 

--- a/examples/example.rs
+++ b/examples/example.rs
@@ -22,15 +22,15 @@ async fn main() {
     website.crawl().await;
     let duration = start.elapsed();
 
-    let pages = website.get_pages();
+    let links = website.get_links();
 
-    for page in &pages {
-        println!("- {:?}", page.get_url());
+    for link in links {
+        println!("- {:?}", link.as_ref());
     }
 
     println!(
         "Time elapsed in website.crawl() is: {:?} for total pages: {:?}",
         duration,
-        pages.len()
+        links.len()
     )
 }

--- a/spider/Cargo.toml
+++ b/spider/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spider"
-version = "1.19.17"
+version = "1.19.18"
 authors = ["madeindjs <contact@rousseau-alexandre.fr>", "j-mendez <jeff@a11ywatch.com>"]
 description = "Multithreaded web crawler written in Rust."
 repository = "https://github.com/spider-rs/spider"

--- a/spider/README.md
+++ b/spider/README.md
@@ -16,7 +16,7 @@ This is a basic blocking example crawling a web page, add spider to your `Cargo.
 
 ```toml
 [dependencies]
-spider = "1.19.17"
+spider = "1.19.18"
 ```
 
 And then the code:
@@ -62,7 +62,7 @@ There is an optional "regex" crate that can be enabled:
 
 ```toml
 [dependencies]
-spider = { version = "1.19.17", features = ["regex"] }
+spider = { version = "1.19.18", features = ["regex"] }
 ```
 
 ```rust,no_run
@@ -89,7 +89,7 @@ Currently we have three optional feature flags. Regex blacklisting, jemaloc back
 
 ```toml
 [dependencies]
-spider = { version = "1.19.17", features = ["regex", "ua_generator"] }
+spider = { version = "1.19.18", features = ["regex", "ua_generator"] }
 ```
 
 [Jemalloc](https://github.com/jemalloc/jemalloc) performs better for concurrency and allows memory to release easier.
@@ -98,7 +98,7 @@ This changes the global allocator of the program so test accordingly to measure 
 
 ```toml
 [dependencies]
-spider = { version = "1.19.17", features = ["jemalloc"] }
+spider = { version = "1.19.18", features = ["jemalloc"] }
 ```
 
 ## Blocking

--- a/spider/src/configuration.rs
+++ b/spider/src/configuration.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 /// Structure to configure `Website` crawler
 /// ```rust
 /// use spider::website::Website;
@@ -23,6 +25,8 @@ pub struct Configuration {
     pub delay: u64,
     /// Crawl channel buffer tuned to callback.
     pub channel_buffer: i32,
+    /// Request max timeout per page
+    pub request_timeout: Duration
 }
 
 /// get the user agent from the top agent list randomly.
@@ -44,7 +48,8 @@ impl Configuration {
     pub fn new() -> Self {
         Self {
             delay: 0,
-            channel_buffer: 100,
+            channel_buffer: 111,
+            request_timeout: Duration::from_millis(15000),
             ..Default::default()
         }
     }

--- a/spider_cli/Cargo.toml
+++ b/spider_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spider_cli"
-version = "1.19.17"
+version = "1.19.18"
 authors = ["madeindjs <contact@rousseau-alexandre.fr>", "j-mendez <jeff@a11ywatch.com>"]
 description = "Multithreaded web crawler written in Rust."
 repository = "https://github.com/spider-rs/spider"
@@ -25,7 +25,7 @@ quote = "1.0.18"
 failure_derive = "0.1.8"
 
 [dependencies.spider]
-version = "1.19.17"
+version = "1.19.18"
 path = "../spider"
 
 [[bin]]

--- a/spider_cli/README.md
+++ b/spider_cli/README.md
@@ -34,7 +34,7 @@ spider --domain https://choosealicense.com crawl -o > spider_choosealicense.json
 ```
 
 ```sh
-spider_cli 1.19.17
+spider_cli 1.19.18
 madeindjs <contact@rousseau-alexandre.fr>, j-mendez <jeff@a11ywatch.com>
 Multithreaded web crawler written in Rust.
 


### PR DESCRIPTION
1. add client configs for large scanning

Local mac m1 results avg

```
Time elapsed in website.crawl() is: 153.99869s for total pages: 23198
        Command being timed: "./target/release/examples/example"
        User time (seconds): 78.69
        System time (seconds): 16.48
        Percent of CPU this job got: 61%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 2:34.50
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 1498576
        Average resident set size (kbytes): 0
        Major (requiring I/O) page faults: 24
        Minor (reclaiming a frame) page faults: 457897
        Voluntary context switches: 25774
        Involuntary context switches: 566372
        Swaps: 0
        File system inputs: 0
        File system outputs: 0
        Socket messages sent: 167475
        Socket messages received: 756187
        Signals delivered: 0
        Page size (bytes): 16384
        Exit status: 0
```

-- lb

```
Time elapsed in website.crawl() is: 273.785813375s for total pages: 24842
        Command being timed: "./target/release/examples/example"
        User time (seconds): 94.19
        System time (seconds): 14.48
        Percent of CPU this job got: 39%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 4:34.08
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 680416
        Average resident set size (kbytes): 0
        Major (requiring I/O) page faults: 24
        Minor (reclaiming a frame) page faults: 558217
        Voluntary context switches: 5271
        Involuntary context switches: 454522
        Swaps: 0
        File system inputs: 0
        File system outputs: 0
        Socket messages sent: 67994
        Socket messages received: 676362
        Signals delivered: 0
        Page size (bytes): 16384
        Exit status: 0
```
