### PR TITLE
bench(decentralized): add decentralized worker split case

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -28,7 +28,11 @@ jobs:
             ~/.cargo/git/db/
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      - name: Run Benchmark Compare OSS
-        run: cargo bench --bench crawl
-      - name: Run Benchmark Massive 50k pages plus
-        run: cargo bench --bench crawl_massive
+      # - name: Run Benchmark Compare OSS
+      #   run: cargo bench --bench crawl
+      - name: Run Benchmark Compare OSS - Features[decentralized]
+        run: cargo bench --bench crawl --features decentralized
+      # - name: Run Benchmark Massive 50k pages plus
+      #   run: cargo bench --bench crawl_massive
+      - name: Run Benchmark Massive 50k pages plus - Features[decentralized]
+        run: cargo bench --bench crawl_massive --features decentralized

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -17,3 +17,6 @@ harness = false
 name = "crawl_massive"
 path = "crawl_massive.rs"
 harness = false
+
+[features]
+decentralized = ["spider/decentralized"]

--- a/benches/build.rs
+++ b/benches/build.rs
@@ -8,6 +8,11 @@ pub fn main() {
     node_crawler::gen_crawl();
     go_crolly::gen_crawl();
 
+    // install spider_worker
+    Command::new("cargo")
+        .args(["install", "spider_worker"])
+        .output()
+        .expect("cargo install spider_worker failed");
     // install go deps
     Command::new("go")
         .args(["mod", "init", "example.com/gospider"])

--- a/spider/README.md
+++ b/spider/README.md
@@ -185,9 +185,9 @@ spider = { version = "1.29.0", features = ["decentralized"] }
 
 ```sh
 # install the worker
-SPIDER_WORKER_PORT=3030 cargo install spider_worker
+cargo install spider_worker
 # start the worker [set the worker on another machine in prod]
-RUST_LOG=info spider_worker
+RUST_LOG=info SPIDER_WORKER_PORT=3030 spider_worker
 # start rust project as normal with SPIDER_WORKER env variable
 SPIDER_WORKER=http://127.0.0.1:3030 cargo run --example example --features decentralized
 ```


### PR DESCRIPTION
# Bench

Test `spider_worker` split runtime handling bytes processing bench. The worker in a real world case would not be on the same machine for the most part.

Leveraging the worker to split the IO/CPU work across two runtimes seems to balance out well.

—

Spider with the worker benches around 10k pages per min on the small GitHub action runner. Drastically faster than the default.