### PR TITLE
docs(fix): fix error in "scrape/gather html" section

### DIFF
--- a/spider/README.md
+++ b/spider/README.md
@@ -248,7 +248,7 @@ async fn main() {
 
     let separator = "-".repeat(url.len());
 
-    for page in website.get_pages().unwrap() {
+    for page in website.get_pages().unwrap().iter() {
         writeln!(
             lock,
             "{}\n{}\n\n{}\n\n{}",


### PR DESCRIPTION
Hi, I tried using the example in the "scrape/gather html" section but to no success. 
I added `.iter()` to the for each loop and it worked. 
I'm new to Rust, so I'm not sure, if there is a better method.