### PR TITLE
Return status code on error

### DIFF
--- a/spider/src/page.rs
+++ b/spider/src/page.rs
@@ -715,6 +715,19 @@ async fn parse_links() {
 
 #[cfg(all(not(feature = "decentralized"), not(feature = "chrome")))]
 #[tokio::test]
+async fn test_status_code() {
+    let client = Client::builder()
+        .user_agent("spider/1.1.2")
+        .build()
+        .unwrap();
+    let link_result = "https://choosealicense.com/does-not-exist";
+    let page: Page = Page::new(&link_result, &client).await;
+
+    assert_eq!(page.status_code.as_u16(), 404);
+}
+
+#[cfg(all(not(feature = "decentralized"), not(feature = "chrome")))]
+#[tokio::test]
 async fn test_abs_path() {
     let client = Client::builder()
         .user_agent("spider/1.1.2")

--- a/spider/src/utils.rs
+++ b/spider/src/utils.rs
@@ -105,7 +105,12 @@ pub async fn fetch_page_html_raw(target_url: &str, client: &Client) -> PageRespo
                 ..Default::default()
             }
         }
-        Ok(_) => Default::default(),
+        Ok(res) => {
+            PageResponse {
+                status_code: res.status(),
+                ..Default::default()
+            }
+        }
         Err(_) => {
             log("- error parsing html text {}", &target_url);
             Default::default()


### PR DESCRIPTION
When a request returns an error status, the resulting page will always contain the default status code (200). This change will return the actual status code.