### PR TITLE
chore(cli): trigger help page on missing arguments

### DIFF
--- a/spider_cli/src/options/args.rs
+++ b/spider_cli/src/options/args.rs
@@ -4,6 +4,7 @@ use clap::Parser;
 /// program to crawl a website and gather valid web urls.
 #[derive(Parser)]
 #[clap(author, version, about, long_about = None)]
+#[command(arg_required_else_help = true)]
 pub struct Cli {
     /// Build main sub commands
     #[clap(subcommand)]


### PR DESCRIPTION
Before: 
<img width="731" alt="Screenshot 2025-02-12 at 9 08 37 PM" src="https://github.com/user-attachments/assets/c9b391da-cac3-48a3-93f3-f8d2c1f39be3" />


Now: 
<img width="1486" alt="Screenshot 2025-02-12 at 9 07 09 PM" src="https://github.com/user-attachments/assets/081dfa0f-bf0e-4838-bafa-0cb43ae1575f" />
