### PR TITLE
feat(chrome): add support for wss connection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6779,7 +6779,9 @@ checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
 dependencies = [
  "futures-util",
  "log",
+ "native-tls",
  "tokio",
+ "tokio-native-tls",
  "tungstenite 0.26.2",
 ]
 
@@ -7032,6 +7034,7 @@ dependencies = [
  "http 1.3.1",
  "httparse",
  "log",
+ "native-tls",
  "rand 0.9.0",
  "sha1 0.10.6",
  "thiserror 2.0.12",

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,9 +1,7 @@
 [package]
 name = "spider_examples"
 version = "2.33.14"
-authors = [
-    "j-mendez <jeff@spider.cloud>",
-]
+authors = ["j-mendez <jeff@spider.cloud>"]
 description = "Multithreaded web crawler written in Rust."
 repository = "https://github.com/spider-rs/spider"
 readme = "README.md"
@@ -80,7 +78,11 @@ required-features = ["spider/sync", "spider/cache"]
 [[example]]
 name = "cache_chrome_hybrid"
 path = "cache_chrome_hybrid.rs"
-required-features = ["spider/sync", "spider/chrome", "spider/cache_chrome_hybrid"]
+required-features = [
+    "spider/sync",
+    "spider/chrome",
+    "spider/cache_chrome_hybrid",
+]
 
 [[example]]
 name = "rss"
@@ -139,6 +141,15 @@ path = "chrome_remote.rs"
 required-features = ["spider/sync", "spider/chrome"]
 
 [[example]]
+name = "chrome_remote_tls"
+path = "chrome_remote_tls.rs"
+required-features = [
+    "spider/sync",
+    "spider/chrome",
+    "spider/chrome_tls_connection",
+]
+
+[[example]]
 name = "chrome_sendable"
 path = "chrome_sendable.rs"
 required-features = ["spider/sync", "spider/chrome"]
@@ -146,7 +157,11 @@ required-features = ["spider/sync", "spider/chrome"]
 [[example]]
 name = "real_world"
 path = "real_world.rs"
-required-features = ["spider/sync", "spider/chrome", "spider_utils/transformations"]
+required-features = [
+    "spider/sync",
+    "spider/chrome",
+    "spider_utils/transformations",
+]
 
 [[example]]
 name = "chrome_viewport"

--- a/examples/chrome_remote_tls.rs
+++ b/examples/chrome_remote_tls.rs
@@ -1,0 +1,68 @@
+//! cargo run --example chrome_remote_tls --features="chrome chrome_intercept chrome_tls_connection"
+
+extern crate spider;
+use crate::spider::tokio::io::AsyncWriteExt;
+use spider::features::chrome_common::RequestInterceptConfiguration;
+use spider::tokio;
+use spider::website::Website;
+use std::io::Result;
+
+async fn crawl_website(url: &str) -> Result<()> {
+    let mut website: Website = Website::new(url)
+        .with_limit(500)
+        .with_chrome_intercept(RequestInterceptConfiguration::new(true))
+        .with_stealth(true)
+        .with_fingerprint(true)
+        // .with_proxies(Some(vec!["http://localhost:8888".into()]))
+        .with_chrome_connection(Some(
+            "wss://replace_this_with_your_connection_string".into(),
+        ))
+        .build()
+        .unwrap();
+
+    let mut rx2 = website.subscribe(16).unwrap();
+    let mut stdout = tokio::io::stdout();
+
+    tokio::spawn(async move {
+        while let Ok(page) = rx2.recv().await {
+            let _ = stdout
+                .write_all(
+                    format!(
+                        "- {} -- Bytes transferred {:?} -- HTML Size {:?}\n",
+                        page.get_url(),
+                        page.bytes_transferred.unwrap_or_default(),
+                        page.get_html_bytes_u8().len()
+                    )
+                    .as_bytes(),
+                )
+                .await;
+        }
+    });
+
+    let start = crate::tokio::time::Instant::now();
+    website.crawl().await;
+
+    let duration = start.elapsed();
+
+    let links = website.get_all_links_visited().await;
+
+    println!(
+        "Time elapsed in website.crawl({}) is: {:?} for total pages: {:?}",
+        website.get_url(),
+        duration,
+        links.len()
+    );
+
+    Ok(())
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let _ = tokio::join!(
+        crawl_website("https://choosealicense.com"),
+        crawl_website("https://jeffmendez.com"),
+        crawl_website("https://example.com"),
+    );
+
+    Ok(())
+}

--- a/spider/Cargo.toml
+++ b/spider/Cargo.toml
@@ -1,9 +1,7 @@
 [package]
 name = "spider"
 version = "2.34.4"
-authors = [
-    "j-mendez <jeff@spider.cloud>"
-]
+authors = ["j-mendez <jeff@spider.cloud>"]
 description = "A web crawler and scraper, building blocks for data curation workloads."
 repository = "https://github.com/spider-rs/spider"
 readme = "README.md"
@@ -40,14 +38,18 @@ cron = { version = "0.15", optional = true }
 async-trait = { version = "0.1", optional = true }
 strum = { version = "0.26", features = ["derive"] }
 async_job = { version = "0.1", optional = true }
-reqwest-middleware = { version = "0.4", optional = true,  default-features = false }
+reqwest-middleware = { version = "0.4", optional = true, default-features = false }
 http-cache-reqwest = { version = "0.15", optional = true, default-features = false }
 const_format = { version = "0.2", optional = true }
 async-openai = { version = "0.28", optional = true }
 tiktoken-rs = { version = "0.6", optional = true }
 lol_html = { version = "2" }
 serde_json = { version = "1", optional = true }
-quick-xml = { version = "0.37", features = ["serde", "serialize", "async-tokio"]}
+quick-xml = { version = "0.37", features = [
+    "serde",
+    "serialize",
+    "async-tokio",
+] }
 moka = { version = "0.12", features = ["future"], optional = true }
 fastrand = { version = "2", optional = true }
 http-cache-semantics = { version = "2", optional = true }
@@ -57,17 +59,28 @@ phf = "0.11"
 phf_codegen = "0.11"
 auto_encoder = { version = "0.1" }
 base64 = { version = "0.22", optional = true }
-string-interner = { version = "0.19", default-features = false, features = ["std", "inline-more", "backends"], optional = true }
+string-interner = { version = "0.19", default-features = false, features = [
+    "std",
+    "inline-more",
+    "backends",
+], optional = true }
 httpdate = { version = "1", optional = true }
 rand = { version = "0.9", optional = true }
 serde_regex = { version = "1", optional = true }
 statrs = { version = "0.18", optional = true }
 aho-corasick = { version = "1", optional = true }
-tracing = { version = "0.1", default-features = false, features = ["std"], optional = true }
-sysinfo = { version = "0.33", default-features = false, features = ["system"], optional = true }
-sqlx = { version = "0.8", features = [ "runtime-tokio", "sqlite" ], optional = true }
+tracing = { version = "0.1", default-features = false, features = [
+    "std",
+], optional = true }
+sysinfo = { version = "0.33", default-features = false, features = [
+    "system",
+], optional = true }
+sqlx = { version = "0.8", features = [
+    "runtime-tokio",
+    "sqlite",
+], optional = true }
 h2 = "0.4"
-tower = { version = "0.5", features = [ "limit" ]}
+tower = { version = "0.5", features = ["limit"] }
 pin-project-lite = "0.2"
 sonic-rs = { version = "0.3", optional = true }
 
@@ -76,10 +89,7 @@ version = "2"
 path = "../spider_chrome"
 optional = true
 default-features = false
-features = [
-    "bytes",
-    "stream"
-]
+features = ["bytes", "stream"]
 
 [dependencies.spider_firewall]
 version = "2"
@@ -93,7 +103,7 @@ libc = "0.2"
 tokio = { version = "1", default-features = false, features = [
     "macros",
     "time",
-    "rt-multi-thread"
+    "rt-multi-thread",
 ] }
 fastrand = { version = "2", optional = true }
 reqwest = { version = "0.12", features = [
@@ -108,7 +118,7 @@ reqwest = { version = "0.12", features = [
 tokio = { version = "1", default-features = false, features = [
     "macros",
     "time",
-    "rt"
+    "rt",
 ] }
 fastrand = { version = "2", optional = true, features = ["js"] }
 reqwest = { version = "0.12", features = [
@@ -120,14 +130,23 @@ reqwest = { version = "0.12", features = [
 
 [features]
 default = ["basic", "io_uring"]
-basic = ["sync", "reqwest_native_tls_native_roots", "disk_native_tls", "cookies", "ua_generator", "encoding", "string_interner_buffer_backend", "balance"]
+basic = [
+    "sync",
+    "reqwest_native_tls_native_roots",
+    "disk_native_tls",
+    "cookies",
+    "ua_generator",
+    "encoding",
+    "string_interner_buffer_backend",
+    "balance",
+]
 disk = ["dep:sqlx", "dep:aho-corasick"]
 disk_native_tls = ["disk", "sqlx/runtime-tokio-native-tls"]
 disk_aws = ["disk", "sqlx/tls-rustls-aws-lc-rs"]
 adblock = ["chrome", "spider_chrome/adblock"]
 balance = ["dep:sysinfo"]
 regex = []
-glob = [ "dep:itertools"]
+glob = ["dep:itertools"]
 ua_generator = ["dep:ua_generator"]
 decentralized = ["serde", "flexbuffers"]
 control = []
@@ -135,7 +154,13 @@ time = []
 io_uring = ["dep:tokio-uring"]
 sync = ["tokio/sync"]
 flexbuffers = ["dep:flexbuffers"]
-serde = ["dep:serde", "hashbrown/serde", "string-interner/serde", "dep:serde_regex", "smallvec/serde"]
+serde = [
+    "dep:serde",
+    "hashbrown/serde",
+    "string-interner/serde",
+    "dep:serde_regex",
+    "smallvec/serde",
+]
 fs = ["tokio/fs"]
 full_resources = []
 socks = ["reqwest/socks"]
@@ -145,8 +170,22 @@ cache_request = ["dep:reqwest-middleware", "dep:http-cache-reqwest"]
 cache = ["cache_request", "http-cache-reqwest/manager-cacache"]
 cache_mem = ["cache_request", "http-cache-reqwest/manager-moka"]
 cache_openai = ["dep:moka"]
-cache_chrome_hybrid = ["cache_request", "cache", "chrome", "dep:http-cache-semantics", "dep:http-cache", "dep:http"]
-cache_chrome_hybrid_mem = ["cache_request", "cache_mem", "chrome", "dep:http-cache-semantics", "dep:http-cache", "dep:http"]
+cache_chrome_hybrid = [
+    "cache_request",
+    "cache",
+    "chrome",
+    "dep:http-cache-semantics",
+    "dep:http-cache",
+    "dep:http",
+]
+cache_chrome_hybrid_mem = [
+    "cache_request",
+    "cache_mem",
+    "chrome",
+    "dep:http-cache-semantics",
+    "dep:http-cache",
+    "dep:http",
+]
 chrome = ["dep:spider_chrome", "dep:base64"]
 chrome_headed = ["chrome"]
 chrome_cpu = ["chrome"]
@@ -156,6 +195,7 @@ chrome_store_page = ["chrome", "serde"]
 chrome_intercept = ["chrome"]
 chrome_headless_new = ["chrome"]
 chrome_simd = ["chrome", "spider_chrome/simd", "simd"]
+chrome_tls_connection = ["chrome", "spider_chrome/chrome_tls_connection"]
 cookies = ["reqwest/cookies"]
 cron = ["dep:async_job", "dep:chrono", "dep:cron", "dep:async-trait"]
 smart = ["chrome", "dep:rand", "chrome_intercept", "dep:aho-corasick"]
@@ -163,7 +203,14 @@ encoding = []
 headers = ["dep:httpdate"]
 remote_addr = []
 real_browser = ["dep:statrs", "dep:rand"]
-openai = ["chrome", "serde", "chrome_intercept", "dep:async-openai", "dep:tiktoken-rs", "dep:serde_json"]
+openai = [
+    "chrome",
+    "serde",
+    "chrome_intercept",
+    "dep:async-openai",
+    "dep:tiktoken-rs",
+    "dep:serde_json",
+]
 openai_slim_fit = []
 decentralized_headers = ["dep:const_format", "dep:itertools"]
 spoof = ["dep:fastrand"]

--- a/spider_chrome/Cargo.toml
+++ b/spider_chrome/Cargo.toml
@@ -2,9 +2,7 @@
 name = "spider_chrome"
 version = "2.34.4"
 rust-version = "1.70"
-authors = [
-    "j-mendez <jeff@spider.cloud>"
-]
+authors = ["j-mendez <jeff@spider.cloud>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
@@ -36,7 +34,7 @@ tokio = { version = "1", features = [
     "fs",
     "macros",
     "process",
-]}
+] }
 tracing = "0.1"
 pin-project-lite = "0.2"
 dunce = "1"
@@ -44,7 +42,10 @@ bytes = { version = "1", features = ["serde"], optional = true }
 reqwest = { version = "0.12" }
 lazy_static = "1"
 phf = { version = "0.11", features = ["macros"] }
-adblock = { version = "0.9", optional = true, default-features = false, features = ["embedded-domain-resolver", "full-regex-handling"] }
+adblock = { version = "0.9", optional = true, default-features = false, features = [
+    "embedded-domain-resolver",
+    "full-regex-handling",
+] }
 rand = "0.8"
 case_insensitive_string = { version = "0.2", features = ["compact", "serde"] }
 hashbrown = { version = "0.15", default-features = true }
@@ -81,11 +82,18 @@ bytes = ["dep:bytes"]
 adblock = ["dep:adblock"]
 simd = ["dep:sonic-rs"]
 firewall = ["dep:spider_firewall"]
+chrome_tls_connection = ["tokio-tungstenite/native-tls"]
 
 # Temporary features until cargo weak dependencies bug is fixed
 # See https://github.com/rust-lang/cargo/issues/10801
-_fetcher-rusttls-tokio = ["fetcher", "spider_chromiumoxide_fetcher/_rustls-tokio"]
-_fetcher-native-tokio = ["fetcher", "spider_chromiumoxide_fetcher/_native-tokio"]
+_fetcher-rusttls-tokio = [
+    "fetcher",
+    "spider_chromiumoxide_fetcher/_rustls-tokio",
+]
+_fetcher-native-tokio = [
+    "fetcher",
+    "spider_chromiumoxide_fetcher/_native-tokio",
+]
 
 [[example]]
 name = "wiki-tokio"


### PR DESCRIPTION
This addresses an issue when using a remote Chrome connection over `wss:` instead of `ws:` or `http:`. I'm unsure if it aligns with the repository's conventions, so please let me know if any adjustments are needed.

Related issue in chromiumoxide: https://github.com/mattsse/chromiumoxide/issues/249