### PR TITLE
fix: errors with page.authenticate

### DIFF
--- a/spider_chrome/src/handler/network.rs
+++ b/spider_chrome/src/handler/network.rs
@@ -299,7 +299,8 @@ impl NetworkManager {
 
     pub fn authenticate(&mut self, credentials: Credentials) {
         self.credentials = Some(credentials);
-        self.update_protocol_request_interception()
+        self.update_protocol_request_interception();
+        self.protocol_request_interception_enabled = true;
     }
 
     fn update_protocol_request_interception(&mut self) {
@@ -308,7 +309,6 @@ impl NetworkManager {
         if enabled == self.protocol_request_interception_enabled {
             return;
         }
-        self.protocol_request_interception_enabled = enabled;
 
         if enabled {
             self.push_cdp_request(ENABLE_FETCH.clone())

--- a/spider_chrome/src/handler/network.rs
+++ b/spider_chrome/src/handler/network.rs
@@ -308,6 +308,7 @@ impl NetworkManager {
         if enabled == self.protocol_request_interception_enabled {
             return;
         }
+        self.protocol_request_interception_enabled = enabled;
 
         if enabled {
             self.push_cdp_request(ENABLE_FETCH.clone())


### PR DESCRIPTION
Currently when calling `page.authenticate` there is issues on https://abrahamjuliot.github.io/creepjs/ with certain window property values not being able to be read.

Original solution was mentioned in this pr https://github.com/mattsse/chromiumoxide/pull/247