### PR TITLE
Add serde(default) for Configuration.

### DIFF
--- a/spider/src/configuration.rs
+++ b/spider/src/configuration.rs
@@ -141,6 +141,7 @@ pub struct RequestProxy {
     derive(PartialEq)
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(default))]
 pub struct Configuration {
     /// Respect robots.txt file and not scrape not allowed files. This may slow down crawls if robots.txt file has a delay included.
     pub respect_robots_txt: bool,


### PR DESCRIPTION
A small quality of life improvement for those of us that want to define configurations in external files so we don't need to specify all of the `Configuration` fields.

Thanks!