### PR TITLE
fix(website): resolve relative URLs against page host, not crawl origin

### DIFF
--- a/spider/src/website.rs
+++ b/spider/src/website.rs
@@ -5387,18 +5387,21 @@ impl Website {
                                                                 page.set_external(shared.3.clone());
                                                             }
 
-                                                            let prev_domain = page.base;
+                                                            let prev_domain = page.base.take();
 
-                                                            page.base = shared.9.as_deref().cloned();
+                                                            // Use page's own URL for relative link resolution (not original crawl domain).
+                                                            // Fixes subdomain pages resolving e.g. href="/path" against wrong host.
+                                                            page.set_url_parsed_direct();
+                                                            let page_base = page.base.clone().map(Box::new);
 
                                                             if return_page_links {
                                                                 page.page_links = Some(Default::default());
                                                             }
 
                                                             let links = if full_resources {
-                                                                page.links_full(&shared.1, &shared.9).await
+                                                                page.links_full(&shared.1, &page_base).await
                                                             } else {
-                                                                page.links(&shared.1, &shared.9).await
+                                                                page.links(&shared.1, &page_base).await
                                                             };
 
                                                             page.base = prev_domain;
@@ -6094,18 +6097,21 @@ impl Website {
                                                                 page.set_external(shared.3.clone());
                                                             }
 
-                                                            let prev_domain = page.base;
+                                                            let prev_domain = page.base.take();
 
-                                                            page.base = shared.9.as_deref().cloned();
+                                                            // Use page's own URL for relative link resolution (not original crawl domain).
+                                                            // Fixes subdomain pages resolving e.g. href="/path" against wrong host.
+                                                            page.set_url_parsed_direct();
+                                                            let page_base = page.base.clone().map(Box::new);
 
                                                             if return_page_links {
                                                                 page.page_links = Some(Default::default());
                                                             }
 
                                                             let links = if full_resources {
-                                                                page.links_full(&shared.1, &shared.9).await
+                                                                page.links_full(&shared.1, &page_base).await
                                                             } else {
-                                                                page.links(&shared.1, &shared.9).await
+                                                                page.links(&shared.1, &page_base).await
                                                             };
 
                                                             page.base = prev_domain;
@@ -6456,17 +6462,21 @@ impl Website {
                                                 page.set_external(shared.3.clone());
                                             }
 
-                                            let prev_domain = page.base;
-                                            page.base = shared.8.as_deref().cloned();
+                                            let prev_domain = page.base.take();
+
+                                            // Use page's own URL for relative link resolution (not original crawl domain).
+                                            // Fixes subdomain pages resolving e.g. href="/path" against wrong host.
+                                            page.set_url_parsed_direct();
+                                            let page_base = page.base.clone().map(Box::new);
 
                                             if return_page_links {
                                                 page.page_links = Some(Default::default());
                                             }
 
                                             let links = if full_resources {
-                                                page.links_full(&shared.1, &shared.8).await
+                                                page.links_full(&shared.1, &page_base).await
                                             } else {
-                                                page.links(&shared.1, &shared.8).await
+                                                page.links(&shared.1, &page_base).await
                                             };
 
                                             page.base = prev_domain;
@@ -6919,9 +6929,12 @@ impl Website {
                                         );
                                     }
 
-                                    let prev_domain = page.base;
+                                    let prev_domain = page.base.take();
 
-                                    page.base = shared.5.as_deref().cloned();
+                                    // Use page's own URL for relative link resolution (not original crawl domain).
+                                    // Fixes subdomain pages resolving e.g. href="/path" against wrong host.
+                                    page.set_url_parsed_direct();
+                                    let page_base = page.base.clone().map(Box::new);
 
                                     if return_page_links {
                                         page.page_links = Some(Default::default());
@@ -6929,7 +6942,7 @@ impl Website {
 
                                     let (links, bytes_transferred ) = page
                                         .smart_links(
-                                            &shared.1, &shared.4, &shared.5, &shared.6, Some(&shared.8)
+                                            &shared.1, &shared.4, &page_base, &shared.6, Some(&shared.8)
                                         )
                                         .await;
 


### PR DESCRIPTION
## Bug

When crawling with `subdomains = true`, relative links on subdomain pages are resolved against the **original crawl domain** instead of the **current page's host**.

### Example

Crawling `www.example.com` with subdomains enabled. A page on `sub.example.com` contains:
```html
<a href="/about">
```

**Before:** Resolves to `www.example.com/about` (wrong)
**After:** Resolves to `sub.example.com/about` (correct)

This causes the crawler to discover and queue phantom URLs that don't actually exist — paths that only live on the subdomain get resolved against the main domain, leading to unnecessary HTTP requests that always return 404.

### Root cause

In `website.rs`, before extracting links, `page.base` is overridden with the original crawl domain (`shared.9` / `shared.8` / `shared.5`). This forces all relative URL resolution through `convert_abs_path()` to use the wrong host for subdomain pages.

### Anti-bot redirect protection is preserved

The original override was designed to handle anti-bot redirects (as noted in `utils/abs.rs`: *"we can swap the domains if they do not match incase of crawler redirect anti-bot"*). This fix does **not** break that protection because `page.url` already stores the **originally queued URL**, not the redirect destination (which is stored separately in `final_redirect_destination`). So when a server redirects to a CDN or challenge page, `set_url_parsed_direct()` still resolves against the original domain — the same behavior as before.

| Scenario | `page.url` | Base resolves to | Behavior |
|---|---|---|---|
| Same-domain page | `www.example.com/page` | `www.example.com` | Unchanged |
| Anti-bot redirect to CDN | `www.example.com/page` | `www.example.com` | Unchanged |
| Subdomain page | `sub.example.com/page` | `sub.example.com` | **Fixed** |

### Fix

Use `page.set_url_parsed_direct()` to set the base URL from `page.url` instead of overriding with the original crawl domain. Domain validation (`parent_host_match`) is unaffected as it uses separate selector parameters, not the `base` URL.

### Real-world impact

On a production site with `www.` and `insights.` subdomains, this bug generated **215 phantom URLs** on `www.` from relative navigation links (like `<a href="/formations">`) found on `insights.` pages — all resolved against the wrong host, all resulting in wasted crawl requests.

### Changes

4 locations in `website.rs` (HTTP crawl, Chrome crawl, headless crawl, smart crawl) — same minimal pattern at each.