### PR TITLE
feat(cli): add wait-for capabilities to spider_cli

### DIFF
--- a/spider_cli/README.md
+++ b/spider_cli/README.md
@@ -89,29 +89,64 @@ Commands:
   help      Print this message or the help of the given subcommand(s)
 
 Options:
-  -u, --url <URL>                      The website URL to crawl
-  -r, --respect-robots-txt             Respect robots.txt file
-  -s, --subdomains                     Allow sub-domain crawling
-  -t, --tld                            Allow all tlds for domain
-  -H, --return-headers                 Return page headers (requires `headers` feature)
-  -v, --verbose                        Print page visited on standard output
-  -D, --delay <DELAY>                  Polite crawling delay in milli seconds
-      --limit <LIMIT>                  The max pages allowed to crawl
-      --blacklist-url <BLACKLIST_URL>  Comma-separated deny list for URLs
-  -a, --agent <AGENT>                  User-Agent
-  -B, --budget <BUDGET>                Crawl budget rules
-  -E, --external-domains <EXTERNAL_DOMAINS>  External domains to include
-  -b, --block-images                   Block image rendering when using Chrome
-  -d, --depth <DEPTH>                  Crawl depth limit
-      --accept-invalid-certs           Dangerously accept invalid certficates
-      --full-resources                 Gather css/js and other page resources
-      --headless                       Use browser rendering mode (headless)
-      --http                           Force HTTP-only mode (no browser rendering)
-  -p, --proxy-url <PROXY_URL>          The proxy url to use
-      --spider-cloud-key <SPIDER_CLOUD_KEY>    Spider Cloud API key
-      --spider-cloud-mode <SPIDER_CLOUD_MODE>  proxy|api|unblocker|fallback|smart
-  -h, --help                           Print help
-  -V, --version                        Print version
+  -u, --url <URL>
+          The website URL to crawl
+  -r, --respect-robots-txt
+          Respect robots.txt file
+  -s, --subdomains
+          Allow sub-domain crawling
+  -t, --tld
+          Allow all tlds for domain
+  -H, --return-headers
+          Return the headers of the page.  Requires the `headers` flag enabled
+  -v, --verbose
+          Print page visited on standard output
+  -D, --delay <DELAY>
+          Polite crawling delay in milli seconds
+      --limit <LIMIT>
+          The max pages allowed to crawl
+      --blacklist-url <BLACKLIST_URL>
+          Comma seperated string list of pages to not crawl or regex with feature enabled
+  -a, --agent <AGENT>
+          User-Agent
+  -B, --budget <BUDGET>
+          Crawl Budget preventing extra paths from being crawled. Use commas to split the path followed by the limit ex: "*,1" - to only allow one page
+  -E, --external-domains <EXTERNAL_DOMAINS>
+          Set external domains to group with crawl
+  -b, --block-images
+          Block Images from rendering when using Chrome. Requires the `chrome_intercept` flag enabled
+  -d, --depth <DEPTH>
+          The crawl depth limits
+      --accept-invalid-certs
+          Dangerously accept invalid certficates
+      --full-resources
+          Gather all content that relates to the domain like css,jss, and etc
+      --headless
+          Use browser rendering mode (headless) for crawl/scrape/download. Requires the `chrome` feature
+      --http
+          Force HTTP-only mode (no browser rendering), even when built with `chrome`
+  -p, --proxy-url <PROXY_URL>
+          The proxy url to use
+      --spider-cloud-key <SPIDER_CLOUD_KEY>
+          Spider Cloud API key. Sign up at https://spider.cloud for an API key
+      --spider-cloud-mode <SPIDER_CLOUD_MODE>
+          Spider Cloud mode: proxy (default), api, unblocker, fallback, or smart [default: proxy]
+      --wait-for-idle-network <WAIT_FOR_IDLE_NETWORK>
+          Wait for network request to be idle within a time frame period (500ms no network connections) with an optional timeout in milliseconds
+      --wait-for-idle-network0 <WAIT_FOR_IDLE_NETWORK0>
+          Wait for network request with a max timeout (0 connections) with an optional timeout in milliseconds
+      --wait-for-almost-idle-network0 <WAIT_FOR_ALMOST_IDLE_NETWORK0>
+          Wait for network to be almost idle with a max timeout (max 2 connections) with an optional timeout in milliseconds
+      --wait-for-idle-dom <WAIT_FOR_IDLE_DOM>
+          Wait for idle dom mutations for target element (defaults to "body") with a 30s timeout
+      --wait-for-selector <WAIT_FOR_SELECTOR>
+          Wait for a specific CSS selector to appear with a 60s timeout
+      --wait-for-delay <WAIT_FOR_DELAY>
+          Wait for a fixed delay in milliseconds
+  -h, --help
+          Print help
+  -V, --version
+          Print version
 ```
 
 All features are available except the Website struct `on_link_find_callback` configuration option.

--- a/spider_cli/src/main.rs
+++ b/spider_cli/src/main.rs
@@ -22,7 +22,9 @@ use tokio::io::AsyncWriteExt;
 use serde_json::{json, Value};
 
 use spider::client::header::{HeaderMap, HeaderValue};
-use spider::features::chrome_common::RequestInterceptConfiguration;
+use spider::features::chrome_common::{
+    RequestInterceptConfiguration, WaitForDelay, WaitForIdleNetwork, WaitForSelector,
+};
 use spider::hashbrown::HashMap;
 use spider::page::Page;
 use spider::string_concat::{string_concat, string_concat_impl};
@@ -31,6 +33,7 @@ use spider::utils::header_utils::header_map_to_hash_map;
 use spider::utils::log;
 use spider::website::{CrawlStatus, Website};
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 use crate::build_folders::build_local_path;
 
@@ -196,6 +199,39 @@ async fn main() {
 
     if let Some(domains) = cli.external_domains {
         website.with_external_domains(Some(domains.into_iter()));
+    }
+
+    if let Some(wait_for_idle_network) = cli.wait_for_idle_network {
+        website.with_wait_for_idle_network(Some(WaitForIdleNetwork::new(Some(
+            Duration::from_millis(wait_for_idle_network),
+        ))));
+    }
+    if let Some(wait_for_idle_network0) = cli.wait_for_idle_network0 {
+        website.with_wait_for_idle_network0(Some(WaitForIdleNetwork::new(Some(
+            Duration::from_millis(wait_for_idle_network0),
+        ))));
+    }
+    if let Some(wait_for_almost_idle_network0) = cli.wait_for_almost_idle_network0 {
+        website.with_wait_for_almost_idle_network0(Some(WaitForIdleNetwork::new(Some(
+            Duration::from_millis(wait_for_almost_idle_network0),
+        ))));
+    }
+    if let Some(selector) = cli.wait_for_idle_dom {
+        website.with_wait_for_idle_dom(Some(WaitForSelector::new(
+            Some(Duration::from_secs(30)),
+            selector,
+        )));
+    }
+    if let Some(selector) = cli.wait_for_selector {
+        website.with_wait_for_selector(Some(WaitForSelector::new(
+            Some(Duration::from_secs(60)),
+            selector,
+        )));
+    }
+    if let Some(wait_for_delay) = cli.wait_for_delay {
+        website.with_wait_for_delay(Some(WaitForDelay::new(Some(Duration::from_millis(
+            wait_for_delay,
+        )))));
     }
 
     let return_headers = cli.return_headers;

--- a/spider_cli/src/options/args.rs
+++ b/spider_cli/src/options/args.rs
@@ -72,4 +72,22 @@ pub struct Cli {
     /// Spider Cloud mode: proxy (default), api, unblocker, fallback, or smart.
     #[clap(long, default_value = "proxy")]
     pub spider_cloud_mode: Option<String>,
+    /// Wait for network request to be idle within a time frame period (500ms no network connections) with an optional timeout in milliseconds.
+    #[clap(long)]
+    pub wait_for_idle_network: Option<u64>,
+    /// Wait for network request with a max timeout (0 connections) with an optional timeout in milliseconds.
+    #[clap(long)]
+    pub wait_for_idle_network0: Option<u64>,
+    /// Wait for network to be almost idle with a max timeout (max 2 connections) with an optional timeout in milliseconds.
+    #[clap(long)]
+    pub wait_for_almost_idle_network0: Option<u64>,
+    /// Wait for idle dom mutations for target element (defaults to "body") with a 30s timeout.
+    #[clap(long)]
+    pub wait_for_idle_dom: Option<String>,
+    /// Wait for a specific CSS selector to appear with a 60s timeout.
+    #[clap(long)]
+    pub wait_for_selector: Option<String>,
+    /// Wait for a fixed delay in milliseconds.
+    #[clap(long)]
+    pub wait_for_delay: Option<u64>,
 }


### PR DESCRIPTION
Introduces several new CLI arguments to `spider_cli` for configuring wait strategies during crawling. These options allow users to control delays based on network activity, DOM mutations, or specific selectors.

Documentation strings for the new CLI flags were copied from `spider/src/configuration.rs`.

### Changes

- Added `wait_for_idle_network`, `wait_for_idle_network0`, and `wait_for_almost_idle_network0` to handle network idle states.
- Added `wait_for_idle_dom` to pause until DOM mutations cease for a target element.
- Added `wait_for_selector` to wait for a specific CSS selector to appear.
- Added `wait_for_delay` for a fixed millisecond delay.
- Updated `main.rs` to apply these configurations to the website instance.
- Regenerated the `spider --help` output in the README.