### PR TITLE
fix: add no_sandbox() to headless BrowserConfig

### DIFF
--- a/spider/src/features/chrome.rs
+++ b/spider/src/features/chrome.rs
@@ -232,6 +232,7 @@ pub fn get_browser_config(
 ) -> Option<BrowserConfig> {
     let builder = BrowserConfig::builder()
         .disable_default_args()
+        .no_sandbox()
         .request_timeout(match request_timeout.as_ref() {
             Some(timeout) => **timeout,
             _ => Duration::from_millis(REQUEST_TIMEOUT),
@@ -538,7 +539,13 @@ pub async fn setup_browser_configuration(
                 browser_config.intercept_manager = config.chrome_intercept.intercept_manager;
                 browser_config.only_html = config.only_html && !config.full_resources;
 
-                (Browser::launch(browser_config).await).ok()
+                match Browser::launch(browser_config).await {
+                    Ok(browser) => Some(browser),
+                    Err(e) => {
+                        log::error!("Browser::launch() failed: {:?}", e);
+                        None
+                    }
+                }
             }
             _ => None,
         },


### PR DESCRIPTION
## Summary

`get_browser_config()` (non-`chrome_headed`) calls `.disable_default_args()` but does not call `.no_sandbox()`.

With the `real_browser` feature (enabled via `basic`), `CHROME_ARGS` is the 24-arg variant that does not include `--no-sandbox`. The `chrome_headed` variant already has `.no_sandbox()` but the headless variant is missing it.

This causes Chrome to exit in Docker environments running as root:
```
Running as root without --no-sandbox is not supported. See https://crbug.com/638180.
```

The error is invisible because `setup_browser_configuration()` uses `.ok()` to discard the launch error.

## Changes

1. Added `.no_sandbox()` to headless `get_browser_config()` — aligns with the `chrome_headed` variant
2. Replaced `.ok()` with `match` + `log::error!` in `setup_browser_configuration()` so `Browser::launch` failures are visible