### PR TITLE
feat: add on_link_blocked_callback for robots.txt blocked URLs

### DIFF
--- a/spider/src/website.rs
+++ b/spider/src/website.rs
@@ -1031,6 +1031,9 @@ pub type OnLinkFindCallback = Arc<
         + Sync,
 >;
 
+/// Callback fired when a link is blocked by robots.txt.
+pub type OnLinkBlockedCallback = Arc<dyn Fn(String) + Send + Sync>;
+
 /// Callback closure that determines if a link should be crawled or not.
 pub trait OnShouldCrawlClosure: Fn(&Page) -> bool + Send + Sync + 'static {}
 impl<F: Fn(&Page) -> bool + Send + Sync + 'static> OnShouldCrawlClosure for F {}
@@ -1120,6 +1123,8 @@ pub struct Website {
     pub on_link_find_callback: Option<OnLinkFindCallback>,
     /// The callback to use if a page should be ignored. Return false to ensure that the discovered links are not crawled.
     pub on_should_crawl_callback: Option<OnShouldCrawlCallback>,
+    /// Callback fired when a link is blocked by robots.txt.
+    pub on_link_blocked_callback: Option<OnLinkBlockedCallback>,
     /// Custom retry strategy that controls retry behavior per attempt.
     /// When set, this takes precedence over the simple `Configuration::retry` counter.
     pub retry_strategy: Option<crate::retry_strategy::SharedRetryStrategy>,
@@ -1812,8 +1817,15 @@ impl Website {
 
         let blocked_whitelist = !whitelist.is_empty() && !contains(whitelist, link.inner());
         let blocked_blacklist = !blacklist.is_empty() && contains(blacklist, link.inner());
+        let blocked_robots = !self.is_allowed_robots(link.as_ref());
 
-        if blocked_whitelist || blocked_blacklist || !self.is_allowed_robots(link.as_ref()) {
+        if blocked_robots {
+            if let Some(cb) = &self.on_link_blocked_callback {
+                cb(link.as_ref().to_string());
+            }
+        }
+
+        if blocked_whitelist || blocked_blacklist || blocked_robots {
             ProcessLinkStatus::Blocked
         } else {
             ProcessLinkStatus::Allowed
@@ -1833,8 +1845,15 @@ impl Website {
 
         let blocked_whitelist = !whitelist.is_empty() && !contains(whitelist, link);
         let blocked_blacklist = !blacklist.is_empty() && contains(blacklist, link);
+        let blocked_robots = !self.is_allowed_robots(link);
 
-        if blocked_whitelist || blocked_blacklist || !self.is_allowed_robots(link) {
+        if blocked_robots {
+            if let Some(cb) = &self.on_link_blocked_callback {
+                cb(link.to_string());
+            }
+        }
+
+        if blocked_whitelist || blocked_blacklist || blocked_robots {
             ProcessLinkStatus::Blocked
         } else {
             ProcessLinkStatus::Allowed
@@ -12726,6 +12745,18 @@ impl Website {
             + 'static,
     {
         self.on_link_find_callback = Some(Arc::new(f));
+    }
+
+    /// Set a callback fired when a link is blocked by robots.txt.
+    pub fn with_on_link_blocked_callback<F: Fn(String) + Send + Sync + 'static>(
+        &mut self,
+        callback: Option<F>,
+    ) -> &mut Self {
+        match callback {
+            Some(cb) => self.on_link_blocked_callback = Some(Arc::new(cb)),
+            None => self.on_link_blocked_callback = None,
+        };
+        self
     }
 
     /// Use a callback to determine if a page should be ignored. Return false to ensure that the discovered links are not crawled.

--- a/spider/src/website.rs
+++ b/spider/src/website.rs
@@ -1817,15 +1817,13 @@ impl Website {
 
         let blocked_whitelist = !whitelist.is_empty() && !contains(whitelist, link.inner());
         let blocked_blacklist = !blacklist.is_empty() && contains(blacklist, link.inner());
-        let blocked_robots = !self.is_allowed_robots(link.as_ref());
 
-        if blocked_robots {
+        if blocked_whitelist || blocked_blacklist {
+            ProcessLinkStatus::Blocked
+        } else if !self.is_allowed_robots(link.as_ref()) {
             if let Some(cb) = &self.on_link_blocked_callback {
                 cb(link.as_ref().to_string());
             }
-        }
-
-        if blocked_whitelist || blocked_blacklist || blocked_robots {
             ProcessLinkStatus::Blocked
         } else {
             ProcessLinkStatus::Allowed
@@ -1845,15 +1843,13 @@ impl Website {
 
         let blocked_whitelist = !whitelist.is_empty() && !contains(whitelist, link);
         let blocked_blacklist = !blacklist.is_empty() && contains(blacklist, link);
-        let blocked_robots = !self.is_allowed_robots(link);
 
-        if blocked_robots {
+        if blocked_whitelist || blocked_blacklist {
+            ProcessLinkStatus::Blocked
+        } else if !self.is_allowed_robots(link) {
             if let Some(cb) = &self.on_link_blocked_callback {
                 cb(link.to_string());
             }
-        }
-
-        if blocked_whitelist || blocked_blacklist || blocked_robots {
             ProcessLinkStatus::Blocked
         } else {
             ProcessLinkStatus::Allowed


### PR DESCRIPTION
I'm using spider for SEO-crawling, and need to know which URLs are blocked by robots.txt.

## What does this PR do?

Add an OnLinkBlockedCallback that fires when a link is denied by robots.txt rules, allowing consumers to observe and log blocked URLs without extra polling.

Co-Authored by Claude Opus 4.7

## Checklist

- [x] `cargo test` passes
- [x] `cargo fmt` applied
- [x] New public APIs have doc comments
- [ ] Feature-gated behind a flag (if adding optional functionality)
