### PR TITLE
Fix 500ms timeout for proxy error statuses 598/599

### DIFF
--- a/spider/src/page.rs
+++ b/spider/src/page.rs
@@ -13366,7 +13366,7 @@ fn test_get_timeout_proxy_errors() {
         let timeout = page.get_timeout();
         assert_eq!(
             timeout,
-            Some(std::time::Duration::from_millis(1_500)),
+            Some(std::time::Duration::from_millis(500)),
             "{code} → 500ms"
         );
     }


### PR DESCRIPTION
## What does this PR do?

The test expected **1500ms** for status codes 598 and 599, but `Page::get_timeout()` returns **500ms** for those codes (introduced in a PR by @j-mendez about 2 months ago).

## How was this tested?

`cargo test -p spider`

## Checklist

- [ ] `cargo test` passes
- [x] `cargo fmt` applied
- [x] New public APIs have doc comments
- [x] Feature-gated behind a flag (if adding optional functionality)

## Follow-up

It may be worth extending `.github/workflows/rust.yml` after this lands.