### PR TITLE
feat(chrome_intercept): with_remote_local_policy (spider 2.52.0)

### DIFF
--- a/spider/Cargo.toml
+++ b/spider/Cargo.toml
@@ -119,7 +119,7 @@ tikv-jemallocator = { version = "0.6", optional = true }
 mimalloc = { version = "0.1", optional = true, default-features = false }
 
 [dependencies.chromey]
-version = "2.50"
+version = "2"
 optional = true
 default-features = false
 features = ["bytes", "stream"]

--- a/spider/Cargo.toml
+++ b/spider/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spider"
-version = "2.51.208"
+version = "2.52.0"
 authors = ["j-mendez <jeff@spider.cloud>"]
 description = "A web crawler and scraper, building blocks for data curation workloads."
 repository = "https://github.com/spider-rs/spider"
@@ -119,7 +119,7 @@ tikv-jemallocator = { version = "0.6", optional = true }
 mimalloc = { version = "0.1", optional = true, default-features = false }
 
 [dependencies.chromey]
-version = "2"
+version = "2.50"
 optional = true
 default-features = false
 features = ["bytes", "stream"]

--- a/spider/src/configuration.rs
+++ b/spider/src/configuration.rs
@@ -1972,6 +1972,28 @@ impl Configuration {
         self
     }
 
+    #[cfg(feature = "chrome_intercept")]
+    /// Push the interception policy (the `chrome_intercept` flags + per-job
+    /// blacklist/whitelist + page url) to a capable remote rendering engine
+    /// once per navigation, so it resolves block/allow decisions locally
+    /// instead of round-tripping every paused request. Enables request
+    /// interception. No-op against a normal Chrome target (the vendor method is
+    /// ignored), so it only changes behavior for engines that implement it.
+    pub fn with_remote_local_policy(&mut self, enabled: bool) -> &mut Self {
+        if enabled {
+            self.chrome_intercept.enabled = true;
+        }
+        self.chrome_intercept.set_remote_local_policy(enabled);
+        self
+    }
+
+    #[cfg(not(feature = "chrome_intercept"))]
+    /// Push the interception policy to a capable remote rendering engine. This
+    /// method does nothing without the `chrome_intercept` flag.
+    pub fn with_remote_local_policy(&mut self, _enabled: bool) -> &mut Self {
+        self
+    }
+
     #[cfg(feature = "chrome")]
     /// Set the connection url for the chrome instance. This method does nothing if the `chrome` is not enabled.
     pub fn with_chrome_connection(&mut self, chrome_connection_url: Option<String>) -> &mut Self {

--- a/spider/src/features/chrome.rs
+++ b/spider/src/features/chrome.rs
@@ -426,6 +426,7 @@ pub fn create_handler_config(config: &Configuration) -> HandlerConfig {
             _ => None,
         },
         intercept_manager: config.chrome_intercept.intercept_manager,
+        remote_local_policy: config.chrome_intercept.remote_local_policy,
         only_html: config.only_html && !config.full_resources,
         max_bytes_allowed: config.max_bytes_allowed,
         // Only enforce the redirect cap on the Chrome path when the user

--- a/spider/src/features/chrome_common.rs
+++ b/spider/src/features/chrome_common.rs
@@ -1062,6 +1062,13 @@ pub struct RequestInterceptConfiguration {
     pub whitelist_patterns: Option<Vec<String>>,
     /// Blacklist patterns.
     pub blacklist_patterns: Option<Vec<String>>,
+    /// Push the interception policy (these flags + the per-job
+    /// blacklist/whitelist + page url) to a capable remote rendering engine
+    /// once per navigation, so it resolves block/allow decisions locally
+    /// instead of round-tripping every paused request. Default `false`. Safe
+    /// against a normal Chrome target (the vendor method is ignored), so this
+    /// only changes behavior for engines that implement it.
+    pub remote_local_policy: bool,
 }
 
 impl Default for RequestInterceptConfiguration {
@@ -1082,6 +1089,7 @@ impl Default for RequestInterceptConfiguration {
             intercept_manager: NetworkInterceptManager::default(),
             whitelist_patterns: None,
             blacklist_patterns: None,
+            remote_local_policy: false,
         }
     }
 }
@@ -1128,6 +1136,13 @@ impl RequestInterceptConfiguration {
     /// Set the blacklist patterns.
     pub fn set_blacklist_patterns(&mut self, blacklist_patterns: Option<Vec<String>>) {
         self.blacklist_patterns = blacklist_patterns;
+    }
+
+    /// Push the interception policy to a capable remote rendering engine once
+    /// per navigation so it resolves block/allow locally (no per-request
+    /// round-trip). No-op against a normal Chrome target.
+    pub fn set_remote_local_policy(&mut self, enabled: bool) {
+        self.remote_local_policy = enabled;
     }
 
     /// Block all request besides html and the important stuff.

--- a/spider/src/website.rs
+++ b/spider/src/website.rs
@@ -13178,6 +13178,17 @@ impl Website {
         self
     }
 
+    /// Push the request-interception policy to a capable remote rendering
+    /// engine once per navigation so it resolves block/allow decisions locally
+    /// (the firewall/adblock lists stay baked into the engine; only the small
+    /// per-job flags + blacklist/whitelist travel, once), eliminating the
+    /// per-request round-trip. Enables request interception. No-op against a
+    /// normal Chrome target. Does nothing without the `chrome_intercept` flag.
+    pub fn with_remote_local_policy(&mut self, enabled: bool) -> &mut Self {
+        self.configuration.with_remote_local_policy(enabled);
+        self
+    }
+
     /// Add a referer to the request.
     pub fn with_referer(&mut self, referer: Option<String>) -> &mut Self {
         self.configuration.with_referer(referer);


### PR DESCRIPTION
## What
Opt-in path to push the per-job interception policy to a capable remote rendering engine once per navigation, so it resolves block/allow **locally** instead of round-tripping every `Fetch.requestPaused`.

- `RequestInterceptConfiguration.remote_local_policy` + `set_remote_local_policy`; mapped into chromey's `HandlerConfig` in `create_handler_config`.
- `Configuration::with_remote_local_policy` and `Website::with_remote_local_policy` (enables interception; no-op without `chrome_intercept`).
- The user's `network_blacklist` → `blacklist_patterns` already flows through this — it travels once in the policy.

## Deps / version
- Requires **chromey 2.50** (the `Interception.setPolicy` emission — spider-rs/chromey#14).
- spider `2.51.208 → 2.52.0` (additive public API).

## Safety
Default `false`: byte-identical behavior unless opted in; a normal Chrome target ignores the vendor method.

## Notes
- `Cargo.lock` will update to chromey 2.50.0 once that crate is published (publish order: chromey first, then spider).
- Verified: spider builds with `--features chrome,chrome_intercept` against chromey 2.50.0 (local patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)