### PR TITLE
feat(chrome): env knobs for failover retry counts + mark-dead cooldown floor (v2.52.8)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1107,7 +1107,7 @@ version = "0.0.0"
 dependencies = [
  "criterion",
  "spider",
- "spider_utils 2.52.7",
+ "spider_utils 2.52.8",
 ]
 
 [[package]]
@@ -9104,7 +9104,7 @@ dependencies = [
 
 [[package]]
 name = "spider"
-version = "2.52.7"
+version = "2.52.8"
 dependencies = [
  "ahash",
  "aho-corasick",
@@ -9244,7 +9244,7 @@ dependencies = [
 
 [[package]]
 name = "spider_agent"
-version = "2.52.7"
+version = "2.52.8"
 dependencies = [
  "aho-corasick",
  "async-openai 0.35.0",
@@ -9284,7 +9284,7 @@ dependencies = [
 
 [[package]]
 name = "spider_agent_html"
-version = "2.52.7"
+version = "2.52.8"
 dependencies = [
  "aho-corasick",
  "lol_html",
@@ -9295,7 +9295,7 @@ dependencies = [
 
 [[package]]
 name = "spider_agent_types"
-version = "2.52.7"
+version = "2.52.8"
 dependencies = [
  "aho-corasick",
  "llm_models_spider",
@@ -9345,7 +9345,7 @@ dependencies = [
 
 [[package]]
 name = "spider_cli"
-version = "2.52.7"
+version = "2.52.8"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -9421,7 +9421,7 @@ dependencies = [
 
 [[package]]
 name = "spider_mcp"
-version = "2.52.7"
+version = "2.52.8"
 dependencies = [
  "clap",
  "dashmap",
@@ -9557,7 +9557,7 @@ dependencies = [
 
 [[package]]
 name = "spider_utils"
-version = "2.52.7"
+version = "2.52.8"
 dependencies = [
  "hashbrown 0.17.1",
  "indexmap",
@@ -9572,7 +9572,7 @@ dependencies = [
 
 [[package]]
 name = "spider_worker"
-version = "2.52.7"
+version = "2.52.8"
 dependencies = [
  "env_logger",
  "hyper",

--- a/spider/Cargo.toml
+++ b/spider/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spider"
-version = "2.52.7"
+version = "2.52.8"
 authors = ["j-mendez <jeff@spider.cloud>"]
 description = "A web crawler and scraper, building blocks for data curation workloads."
 repository = "https://github.com/spider-rs/spider"
@@ -140,11 +140,11 @@ features = ["serde", "headers", "dynamic-versions"]
 
 [dependencies.spider_agent_types]
 path = "../spider_agent_types"
-version = "2.52.7"
+version = "2.52.8"
 
 [dependencies.spider_agent]
 path = "../spider_agent"
-version = "2.52.7"
+version = "2.52.8"
 optional = true
 default-features = false
 

--- a/spider/src/features/chrome.rs
+++ b/spider/src/features/chrome.rs
@@ -450,6 +450,25 @@ pub fn create_handler_config(config: &Configuration) -> HandlerConfig {
 
 lazy_static! {
     static ref CHROM_BASE: Option<String> = std::env::var("CHROME_URL").ok();
+    /// Per-endpoint connect retries for the multi-URL failover ring before
+    /// rotating to the next endpoint (`SPIDER_CHROME_FAILOVER_RETRIES`).
+    /// Default 3 — the prior hardcoded value, so unset is byte-identical.
+    /// Deployments fronting endpoints with an LB that already spreads across
+    /// healthy backends can lower this to fail over faster instead of
+    /// re-dialing a saturated endpoint.
+    static ref CHROME_FAILOVER_RETRIES: u32 = std::env::var("SPIDER_CHROME_FAILOVER_RETRIES")
+        .ok()
+        .and_then(|v| v.parse::<u32>().ok())
+        .unwrap_or(3);
+    /// Connect retries (with backoff) for the single-endpoint path
+    /// (`SPIDER_CHROME_SINGLE_RETRIES`). Default 10 — the prior hardcoded
+    /// value, so unset is byte-identical. Lower it when the endpoint is a
+    /// load balancer that returns fast 5xx under saturation: 11 sequential
+    /// attempts against a rejecting LB just burns the page budget.
+    static ref CHROME_SINGLE_RETRIES: u32 = std::env::var("SPIDER_CHROME_SINGLE_RETRIES")
+        .ok()
+        .and_then(|v| v.parse::<u32>().ok())
+        .unwrap_or(10);
 }
 
 /// Default per-attempt connect timeout for the chrome failover.
@@ -847,7 +866,9 @@ pub async fn setup_browser_configuration(
     // ── Multi-endpoint failover path (priority) ──
     if let Some(ref urls) = config.chrome_connection_urls {
         if !urls.is_empty() {
-            let failover = config.chrome_failover.get_or_init(urls, 3);
+            let failover = config
+                .chrome_failover
+                .get_or_init(urls, *CHROME_FAILOVER_RETRIES);
             return failover
                 .connect(config)
                 .await
@@ -865,7 +886,7 @@ pub async fn setup_browser_configuration(
     match chrome_connection {
         Some(v) => {
             let mut attempts = 0;
-            let max_retries = 10;
+            let max_retries = *CHROME_SINGLE_RETRIES;
             let mut browser = None;
 
             // Bound each connect so a hung remote (cold / over-subscribed pool)

--- a/spider/src/utils/mod.rs
+++ b/spider/src/utils/mod.rs
@@ -4540,16 +4540,29 @@ pub async fn fetch_page_html_chrome_base<'h>(
                         }
                         // Mark the chrome endpoint bad on the failover so
                         // the next setup_browser_configuration call rotates
-                        // away from it. Cooldown matches the timeout (or
-                        // 30s, whichever is longer) so the dead endpoint
-                        // gets at least the watchdog's worth of recovery
-                        // time before being retried.
+                        // away from it. Cooldown matches the timeout or the
+                        // configured floor, whichever is longer, so the dead
+                        // endpoint gets recovery time before being retried.
+                        // Floor tunable via SPIDER_CHROME_MARK_DEAD_COOLDOWN_MS
+                        // (default 30_000 = prior hardcoded value): when the
+                        // endpoint is a load balancer over many backends, one
+                        // page's first-byte timeout says little about the
+                        // whole pool, and a 30s amputation of the entire
+                        // tier over-reacts — deployments like that want a
+                        // short floor instead.
                         if let (Some(ref failover), Some(ref endpoint_url)) =
                             (&chrome_failover_for_watchdog, &chrome_endpoint_for_watchdog)
                         {
+                            static MARK_DEAD_FLOOR_MS: std::sync::LazyLock<u64> =
+                                std::sync::LazyLock::new(|| {
+                                    std::env::var("SPIDER_CHROME_MARK_DEAD_COOLDOWN_MS")
+                                        .ok()
+                                        .and_then(|v| v.parse::<u64>().ok())
+                                        .unwrap_or(30_000)
+                                });
                             let cooldown_ms = std::cmp::max(
                                 timeout.as_millis().min(u128::from(u64::MAX)) as u64,
-                                30_000,
+                                *MARK_DEAD_FLOOR_MS,
                             );
                             failover.mark_url_bad(endpoint_url, cooldown_ms);
                         }

--- a/spider_agent/Cargo.toml
+++ b/spider_agent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spider_agent"
-version = "2.52.7"
+version = "2.52.8"
 authors = ["j-mendez <jeff@spider.cloud>"]
 description = "A concurrent-safe multimodal agent for web automation and research."
 repository = "https://github.com/spider-rs/spider"
@@ -28,8 +28,8 @@ parking_lot = "0.12"
 base64 = "0.22"
 
 # Extracted types and HTML processing
-spider_agent_types = { version = "2.52.7", path = "../spider_agent_types" }
-spider_agent_html = { version = "2.52.7", path = "../spider_agent_html" }
+spider_agent_types = { version = "2.52.8", path = "../spider_agent_types" }
+spider_agent_html = { version = "2.52.8", path = "../spider_agent_html" }
 
 # HTML processing (still needed for engine internals)
 lol_html = "2"

--- a/spider_agent_html/Cargo.toml
+++ b/spider_agent_html/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spider_agent_html"
-version = "2.52.7"
+version = "2.52.8"
 authors = ["j-mendez <jeff@spider.cloud>"]
 description = "HTML processing utilities for spider_agent — cleaning, content analysis, and diffing."
 repository = "https://github.com/spider-rs/spider"
@@ -24,7 +24,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 
 # Types from our types crate
-spider_agent_types = { version = "2.52.7", path = "../spider_agent_types" }
+spider_agent_types = { version = "2.52.8", path = "../spider_agent_types" }
 
 [dev-dependencies]
 serde_json = "1"

--- a/spider_agent_types/Cargo.toml
+++ b/spider_agent_types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spider_agent_types"
-version = "2.52.7"
+version = "2.52.8"
 authors = ["j-mendez <jeff@spider.cloud>"]
 description = "Pure data types and constants for spider_agent automation. Zero heavy dependencies."
 repository = "https://github.com/spider-rs/spider"

--- a/spider_cli/Cargo.toml
+++ b/spider_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spider_cli"
-version = "2.52.7"
+version = "2.52.8"
 authors = ["j-mendez <jeff@spider.cloud>"]
 description = "The fastest web crawler CLI written in Rust."
 repository = "https://github.com/spider-rs/spider"

--- a/spider_mcp/Cargo.toml
+++ b/spider_mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spider_mcp"
-version = "2.52.7"
+version = "2.52.8"
 authors = ["j-mendez <jeff@spider.cloud>"]
 description = "MCP (Model Context Protocol) server exposing Spider web crawler capabilities as tools."
 repository = "https://github.com/spider-rs/spider"

--- a/spider_utils/Cargo.toml
+++ b/spider_utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spider_utils"
-version = "2.52.7"
+version = "2.52.8"
 authors = ["j-mendez <jeff@spider.cloud>"]
 description = "Utilities to use for Spider Web Crawler."
 repository = "https://github.com/spider-rs/spider"

--- a/spider_worker/Cargo.toml
+++ b/spider_worker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spider_worker"
-version = "2.52.7"
+version = "2.52.8"
 authors = ["j-mendez <jeff@spider.cloud>"]
 description = "The fastest web crawler as a worker or proxy."
 repository = "https://github.com/spider-rs/spider"


### PR DESCRIPTION
When the chrome endpoint is a load balancer over many backends, the hardcoded failover behavior over-reacts to a single saturated backend: one page's first-byte timeout marks the WHOLE endpoint dead for >=30s, and connect paths grind through 4 (multi) / 11 (single) sequential attempts against a rejecting LB before failing over.

New env knobs (all LazyLock-cached, defaults = prior hardcoded values, unset is byte-identical):
- `SPIDER_CHROME_FAILOVER_RETRIES` (default 3) — per-endpoint retries in the multi-URL failover ring
- `SPIDER_CHROME_SINGLE_RETRIES` (default 10) — single-endpoint connect retries
- `SPIDER_CHROME_MARK_DEAD_COOLDOWN_MS` (default 30000) — floor of the first-byte-watchdog mark-dead cooldown

Bumps workspace to v2.52.8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)