### PR TITLE
Add pluggable in-process HttpFetchEngine seam

### DIFF
--- a/spider/src/fetch_engine.rs
+++ b/spider/src/fetch_engine.rs
@@ -54,16 +54,11 @@ use crate::configuration::Configuration;
 
 /// HTTP method the engine is asked to perform. Spider's crawl fetch is
 /// always `GET`; the enum leaves room without widening the trait later.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum EngineMethod {
     /// HTTP GET.
+    #[default]
     Get,
-}
-
-impl Default for EngineMethod {
-    fn default() -> Self {
-        EngineMethod::Get
-    }
 }
 
 /// Per-request context handed to an [`HttpFetchEngine`]. Borrowed for the

--- a/spider/src/fetch_engine.rs
+++ b/spider/src/fetch_engine.rs
@@ -1,0 +1,365 @@
+//! Pluggable in-process HTTP fetch engine for [`crate::website::Website`].
+//!
+//! Implementing [`HttpFetchEngine`] and installing it on a
+//! [`Website`](crate::website::Website) via
+//! [`with_fetch_engine`](crate::website::Website::with_fetch_engine)
+//! reroutes spider's per-URL HTTP body fetch through the user's code
+//! **while keeping every surrounding spider concern in spider's hands** —
+//! the first-byte watchdog, truncation retry, TLS scheme-flip retry,
+//! NXDOMAIN short-circuit, cache layers, hedged requests, link
+//! extraction, visited tracking, and [`crate::page::build`] status
+//! reclassification all still wrap the engine call.
+//!
+//! ## How it differs from [`crate::fetcher::RemoteFetcher`]
+//!
+//! [`RemoteFetcher`](crate::fetcher::RemoteFetcher) short-circuits the
+//! *entire* crawl loop before spider's fetch machinery runs — the
+//! implementor owns retries, caching, hedging, everything.
+//!
+//! [`HttpFetchEngine`] is the opposite: it replaces only the innermost
+//! "send the request and read the bytes" step, so spider's machinery
+//! stays wrapped around it. Use this when you want a different transport
+//! for the raw HTTP body but want to keep spider's retry/cache/watchdog
+//! behavior byte-for-byte.
+//!
+//! ## Default behavior unchanged
+//!
+//! A `Website` with **no** engine installed (the default) runs the exact
+//! same reqwest fetch path it always has. The hook is purely additive and
+//! is only compiled in under the `fetch_engine` cargo feature; with the
+//! feature off there is no engine field, no branch, and no cost.
+//!
+//! ## Per-URL opt-in
+//!
+//! [`HttpFetchEngine::should_fetch`] is consulted per URL before the
+//! engine is used. Returning `false` makes spider fall through to its
+//! built-in reqwest fetch for that URL. Any rollout ramp (percentage
+//! gating, per-domain breakers, kill switches) lives inside the
+//! implementor — spider stays transport- and policy-neutral.
+//!
+//! ## Scope (today)
+//!
+//! The engine fires on the **HTTP** crawl paths: the raw streaming path
+//! ([`Website::crawl`](crate::website::Website::crawl) /
+//! [`crawl_raw`](crate::website::Website::crawl_raw)) and the HTTP-first
+//! attempt of the smart path
+//! ([`crawl_smart`](crate::website::Website::crawl_smart)). Browser
+//! navigation (chrome / webdriver, and the smart path's chrome upgrade)
+//! is never routed through the engine.
+
+use std::sync::Arc;
+
+use crate::client::StatusCode;
+use crate::configuration::Configuration;
+
+/// HTTP method the engine is asked to perform. Spider's crawl fetch is
+/// always `GET`; the enum leaves room without widening the trait later.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EngineMethod {
+    /// HTTP GET.
+    Get,
+}
+
+impl Default for EngineMethod {
+    fn default() -> Self {
+        EngineMethod::Get
+    }
+}
+
+/// Per-request context handed to an [`HttpFetchEngine`]. Borrowed for the
+/// duration of one fetch call.
+///
+/// The engine builds and owns its own client, so this carries the raw
+/// crawl configuration (proxies, headers, user agent, timeouts, redirect
+/// limit, cookie string, cert policy, HTTP/2 knob) it needs to match what
+/// spider's reqwest client would have used. Nothing forces the engine to
+/// consult any given field.
+#[derive(Debug)]
+pub struct EngineRequest<'a> {
+    /// The target URL. May be scheme-flipped (`http`↔`https`) or
+    /// `www`-stripped on a TLS-handshake retry, so honor it verbatim.
+    pub url: &'a str,
+    /// The HTTP method (always [`EngineMethod::Get`] today).
+    pub method: EngineMethod,
+    /// The crawl-level configuration for parity with the reqwest path.
+    pub configuration: &'a Configuration,
+    /// When `true`, spider only wants HTML — the engine may early-out on
+    /// clearly-binary bodies. Mirrors the reqwest path's `only_html`.
+    pub only_html: bool,
+    /// Retry attempt counter (0 = first try). A rotation / failover hint.
+    pub attempt: u32,
+    /// Conditional-request validators (ETag / Last-Modified) to send, when
+    /// spider is doing a conditional fetch. `None` for a plain fetch.
+    pub conditional_headers: Option<&'a [(String, String)]>,
+}
+
+/// A completed engine response. The engine returns a fully-decoded body
+/// (decompressed, charset-normalized on its side); spider then applies
+/// the same size caps, UTF-8 validation, anti-bot detection, and status
+/// reclassification it applies to a reqwest response, via
+/// [`crate::utils::handle_engine_response_bytes`].
+#[derive(Debug, Default)]
+pub struct EngineResponse {
+    /// The response status code.
+    pub status_code: StatusCode,
+    /// The final URL after any redirects (set only when it differs from
+    /// the requested URL, matching the reqwest path's redirect detection).
+    pub final_url: Option<String>,
+    /// The response headers.
+    pub headers: reqwest::header::HeaderMap,
+    /// The peer socket address, when the engine can surface it.
+    #[cfg(feature = "remote_addr")]
+    pub remote_addr: Option<core::net::SocketAddr>,
+    /// `Set-Cookie` values parsed the same way spider parses them from a
+    /// reqwest response, so downstream cookie handling sees parity.
+    #[cfg(feature = "cookies")]
+    pub response_cookies: Option<reqwest::header::HeaderMap>,
+    /// The fully-decoded response body.
+    pub body: Vec<u8>,
+    /// The declared `Content-Length`, when known, so spider can detect a
+    /// truncated body (fewer bytes received than promised).
+    pub declared_content_length: Option<u64>,
+    /// Optional anti-bot / WAF classification the engine already computed.
+    /// When `None`, spider runs its own body-based detection.
+    pub anti_bot_tech: Option<crate::page::AntiBotTech>,
+    /// Whether the engine actually served this response (vs. a
+    /// pass-through / synthetic result). Consumers can read this to
+    /// attribute traffic; spider itself does not branch on it.
+    pub served: bool,
+}
+
+/// Transport failure categories. These map onto the same synthetic status
+/// codes and retry decisions spider derives from a `reqwest::Error`, so
+/// the engine path keeps identical retry semantics without spider having
+/// to inspect a concrete error type.
+#[derive(Debug, Clone)]
+pub enum EngineError {
+    /// Request timed out (connect / read / overall). → `524`.
+    Timeout,
+    /// TLS handshake failure. → `526`, and triggers the scheme-flip /
+    /// strip-`www` retry ladder just like the reqwest path.
+    TlsHandshake,
+    /// DNS resolution failed. → `525`.
+    Dns,
+    /// Connection refused by the origin. → `521`.
+    ConnectRefused,
+    /// Connection aborted. → `522`.
+    ConnectAborted,
+    /// Connection reset. → `523`.
+    ConnectReset,
+    /// Host/network permanently unreachable. → `526`.
+    AddressUnreachable,
+    /// Proxy CONNECT / tunnel failure. → `503`, then upgraded to `525`
+    /// if an independent local DNS lookup confirms NXDOMAIN.
+    ProxyTunnel,
+    /// Response body decode failure. → `400`.
+    Body,
+    /// Malformed request. → `400 BAD_REQUEST`.
+    Request,
+    /// A real upstream status the engine wants to surface as an error.
+    Status(u16),
+    /// Anything else. → `599`.
+    Other(String),
+}
+
+impl EngineError {
+    /// Map the error category onto the synthetic status code spider uses
+    /// for the equivalent reqwest failure. Kept in lockstep with the
+    /// `*_ERROR` status constants in [`crate::page`].
+    pub fn to_status_code(&self) -> StatusCode {
+        match self {
+            EngineError::Timeout => *crate::page::CONNECTION_TIMEOUT_ERROR,
+            EngineError::TlsHandshake => *crate::page::ADDRESS_UNREACHABLE_ERROR,
+            EngineError::Dns => *crate::page::DNS_RESOLVE_ERROR,
+            EngineError::ConnectRefused => *crate::page::CONNECTION_REFUSED_ERROR,
+            EngineError::ConnectAborted => *crate::page::CONNECTION_ABORTED_ERROR,
+            EngineError::ConnectReset => *crate::page::CONNECTION_RESET_ERROR,
+            EngineError::AddressUnreachable => *crate::page::ADDRESS_UNREACHABLE_ERROR,
+            EngineError::ProxyTunnel => *crate::page::UNREACHABLE_REQUEST_ERROR,
+            EngineError::Body => *crate::page::BODY_DECODE_ERROR,
+            EngineError::Request => StatusCode::BAD_REQUEST,
+            EngineError::Status(code) => {
+                StatusCode::from_u16(*code).unwrap_or(*crate::page::UNKNOWN_STATUS_ERROR)
+            }
+            EngineError::Other(_) => *crate::page::UNKNOWN_STATUS_ERROR,
+        }
+    }
+
+    /// Whether this failure should trigger spider's TLS scheme-flip /
+    /// strip-`www` retry ladder.
+    pub fn is_handshake_failure(&self) -> bool {
+        matches!(self, EngineError::TlsHandshake)
+    }
+
+    /// Whether this failure is a proxy tunnel/CONNECT error, which spider
+    /// pairs with an independent local-DNS lookup before upgrading to a
+    /// permanent NXDOMAIN (525) status.
+    pub fn is_proxy_tunnel(&self) -> bool {
+        matches!(self, EngineError::ProxyTunnel)
+    }
+}
+
+impl std::fmt::Display for EngineError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            EngineError::Other(msg) => write!(f, "engine error: {msg}"),
+            other => write!(f, "engine error: {other:?}"),
+        }
+    }
+}
+
+impl std::error::Error for EngineError {}
+
+/// User-supplied in-process HTTP fetch transport. When installed on a
+/// [`Website`](crate::website::Website) via
+/// [`with_fetch_engine`](crate::website::Website::with_fetch_engine),
+/// spider invokes [`HttpFetchEngine::fetch`] in place of its inner
+/// `client.get(url).send()` on the HTTP crawl paths, for every URL where
+/// [`HttpFetchEngine::should_fetch`] returns `true`.
+///
+/// The surrounding retry / cache / watchdog / hedge machinery still runs,
+/// so the engine only has to return the body + response metadata for one
+/// request.
+///
+/// Cancellation: the future is dropped on spider's first-byte-timeout, so
+/// honor drop semantics.
+#[async_trait::async_trait]
+pub trait HttpFetchEngine: Send + Sync + 'static {
+    /// Fetch a single URL and return its response, or a categorized
+    /// [`EngineError`] that spider maps onto its retry semantics.
+    async fn fetch(&self, req: EngineRequest<'_>) -> Result<EngineResponse, EngineError>;
+
+    /// Consulted per URL before the engine is used. Returning `false`
+    /// makes spider fall through to its built-in reqwest fetch for that
+    /// URL. Default: always use the engine. Rollout ramps / per-domain
+    /// breakers / kill switches belong here, keeping spider neutral.
+    fn should_fetch(&self, _url: &str) -> bool {
+        true
+    }
+}
+
+/// Type alias used internally by `Website` to store an installed engine.
+/// `Arc<dyn ...>` keeps the slot tiny when unset (`None`).
+pub type SharedHttpFetchEngine = Arc<dyn HttpFetchEngine>;
+
+/// Borrow-only bundle threaded down to spider's leaf fetch primitives so
+/// they can consult the engine and build an [`EngineRequest`]. Cheap to
+/// construct (two references); never clones the configuration.
+#[derive(Copy, Clone)]
+pub struct EngineFetchCtx<'a> {
+    /// The installed engine.
+    pub engine: &'a SharedHttpFetchEngine,
+    /// The crawl configuration to hand the engine for parity.
+    pub configuration: &'a Configuration,
+}
+
+impl<'a> EngineFetchCtx<'a> {
+    /// Construct a context from an engine + configuration reference.
+    pub fn new(engine: &'a SharedHttpFetchEngine, configuration: &'a Configuration) -> Self {
+        Self {
+            engine,
+            configuration,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Every error category maps onto the synthetic status spider uses for
+    /// the equivalent reqwest failure. Locks the mapping so a drift in
+    /// either table is caught.
+    #[test]
+    fn engine_error_status_mapping() {
+        assert_eq!(EngineError::Timeout.to_status_code().as_u16(), 524);
+        assert_eq!(EngineError::TlsHandshake.to_status_code().as_u16(), 526);
+        assert_eq!(EngineError::Dns.to_status_code().as_u16(), 525);
+        assert_eq!(EngineError::ConnectRefused.to_status_code().as_u16(), 521);
+        assert_eq!(EngineError::ConnectAborted.to_status_code().as_u16(), 522);
+        assert_eq!(EngineError::ConnectReset.to_status_code().as_u16(), 523);
+        assert_eq!(EngineError::AddressUnreachable.to_status_code().as_u16(), 526);
+        assert_eq!(EngineError::ProxyTunnel.to_status_code().as_u16(), 503);
+        assert_eq!(EngineError::Body.to_status_code().as_u16(), 400);
+        assert_eq!(EngineError::Request.to_status_code().as_u16(), 400);
+        assert_eq!(EngineError::Status(200).to_status_code().as_u16(), 200);
+        assert_eq!(EngineError::Status(429).to_status_code().as_u16(), 429);
+        assert_eq!(
+            EngineError::Other("boom".into()).to_status_code().as_u16(),
+            599
+        );
+    }
+
+    /// An out-of-range custom status falls back to the unknown-status code.
+    #[test]
+    fn engine_error_invalid_status_falls_back() {
+        assert_eq!(EngineError::Status(999).to_status_code().as_u16(), 999);
+        assert_eq!(EngineError::Status(0).to_status_code().as_u16(), 599);
+    }
+
+    #[test]
+    fn handshake_and_tunnel_predicates() {
+        assert!(EngineError::TlsHandshake.is_handshake_failure());
+        assert!(!EngineError::Timeout.is_handshake_failure());
+        assert!(EngineError::ProxyTunnel.is_proxy_tunnel());
+        assert!(!EngineError::Dns.is_proxy_tunnel());
+    }
+
+    #[test]
+    fn engine_method_default_is_get() {
+        assert_eq!(EngineMethod::default(), EngineMethod::Get);
+    }
+
+    /// A minimal engine that returns a fixed body, exercising the trait
+    /// object surface and the `should_fetch` default + override.
+    struct MockEngine {
+        accept: bool,
+    }
+
+    #[async_trait::async_trait]
+    impl HttpFetchEngine for MockEngine {
+        async fn fetch(&self, req: EngineRequest<'_>) -> Result<EngineResponse, EngineError> {
+            Ok(EngineResponse {
+                status_code: StatusCode::OK,
+                final_url: Some(req.url.to_string()),
+                headers: reqwest::header::HeaderMap::new(),
+                body: b"<html>ok</html>".to_vec(),
+                served: true,
+                ..Default::default()
+            })
+        }
+
+        fn should_fetch(&self, _url: &str) -> bool {
+            self.accept
+        }
+    }
+
+    #[test]
+    fn mock_engine_is_object_safe_and_shareable() {
+        let engine: SharedHttpFetchEngine = std::sync::Arc::new(MockEngine { accept: true });
+        assert!(engine.should_fetch("https://example.com"));
+        let declined: SharedHttpFetchEngine = std::sync::Arc::new(MockEngine { accept: false });
+        assert!(!declined.should_fetch("https://example.com"));
+    }
+
+    #[tokio::test]
+    async fn mock_engine_fetch_returns_body() {
+        let engine = MockEngine { accept: true };
+        let cfg = Configuration::default();
+        let resp = engine
+            .fetch(EngineRequest {
+                url: "https://example.com",
+                method: EngineMethod::Get,
+                configuration: &cfg,
+                only_html: true,
+                attempt: 0,
+                conditional_headers: None,
+            })
+            .await
+            .expect("engine returns ok");
+        assert_eq!(resp.status_code, StatusCode::OK);
+        assert_eq!(resp.body, b"<html>ok</html>");
+        assert_eq!(resp.final_url.as_deref(), Some("https://example.com"));
+        assert!(resp.served);
+    }
+}

--- a/spider/src/fetch_engine.rs
+++ b/spider/src/fetch_engine.rs
@@ -278,7 +278,10 @@ mod tests {
         assert_eq!(EngineError::ConnectRefused.to_status_code().as_u16(), 521);
         assert_eq!(EngineError::ConnectAborted.to_status_code().as_u16(), 522);
         assert_eq!(EngineError::ConnectReset.to_status_code().as_u16(), 523);
-        assert_eq!(EngineError::AddressUnreachable.to_status_code().as_u16(), 526);
+        assert_eq!(
+            EngineError::AddressUnreachable.to_status_code().as_u16(),
+            526
+        );
         assert_eq!(EngineError::ProxyTunnel.to_status_code().as_u16(), 503);
         assert_eq!(EngineError::Body.to_status_code().as_u16(), 400);
         assert_eq!(EngineError::Request.to_status_code().as_u16(), 400);

--- a/spider/src/lib.rs
+++ b/spider/src/lib.rs
@@ -392,13 +392,6 @@ pub mod client;
 pub mod configuration;
 /// Optional features to use.
 pub mod features;
-/// Optional remote-fetch hook — replaces spider's built-in per-URL
-/// network round-trip with a user-supplied transport while leaving
-/// every other crawl concern (tracking, scheduling, link extraction,
-/// subscription channels) in spider's hands. Opt-in via
-/// [`Website::with_remote_fetcher`](crate::website::Website::with_remote_fetcher);
-/// default behavior unchanged when unset.
-pub mod fetcher;
 /// Pluggable in-process HTTP fetch engine. Replaces only spider's inner
 /// body-fetch step while keeping the surrounding retry / cache / watchdog
 /// / hedge machinery wrapped around it. Opt-in at runtime via
@@ -406,6 +399,13 @@ pub mod fetcher;
 /// default `None` keeps every fetch on spider's reqwest path (like the
 /// ungated [`fetcher`] hook).
 pub mod fetch_engine;
+/// Optional remote-fetch hook — replaces spider's built-in per-URL
+/// network round-trip with a user-supplied transport while leaving
+/// every other crawl concern (tracking, scheduling, link extraction,
+/// subscription channels) in spider's hands. Opt-in via
+/// [`Website::with_remote_fetcher`](crate::website::Website::with_remote_fetcher);
+/// default behavior unchanged when unset.
+pub mod fetcher;
 /// Internal packages customized.
 pub mod packages;
 /// A page scraped.

--- a/spider/src/lib.rs
+++ b/spider/src/lib.rs
@@ -399,6 +399,13 @@ pub mod features;
 /// [`Website::with_remote_fetcher`](crate::website::Website::with_remote_fetcher);
 /// default behavior unchanged when unset.
 pub mod fetcher;
+/// Pluggable in-process HTTP fetch engine. Replaces only spider's inner
+/// body-fetch step while keeping the surrounding retry / cache / watchdog
+/// / hedge machinery wrapped around it. Opt-in at runtime via
+/// [`Website::with_fetch_engine`](crate::website::Website::with_fetch_engine);
+/// default `None` keeps every fetch on spider's reqwest path (like the
+/// ungated [`fetcher`] hook).
+pub mod fetch_engine;
 /// Internal packages customized.
 pub mod packages;
 /// A page scraped.

--- a/spider/src/page.rs
+++ b/spider/src/page.rs
@@ -1434,6 +1434,36 @@ pub async fn confirm_tunnel_failure_with_local_dns(
     }
 }
 
+/// Fetch-engine counterpart to [`confirm_tunnel_failure_with_local_dns`].
+///
+/// The engine path reports a proxy tunnel / CONNECT failure as a
+/// categorized `EngineError::ProxyTunnel` rather than a typed
+/// `reqwest::Error`, so this variant takes no error argument. It runs the
+/// same second signal — an independent bounded local DNS lookup — and, on
+/// NXDOMAIN confirmation, upgrades 503 → 525 and populates the shared
+/// cross-transport NXDOMAIN cache so subsequent HTTP or chrome fetches
+/// short-circuit. Same zero-false-positive two-signal contract.
+pub(crate) async fn confirm_engine_tunnel_failure_with_local_dns(
+    target_url: &str,
+    timeout: std::time::Duration,
+) -> StatusCode {
+    let host = match url::Url::parse(target_url)
+        .ok()
+        .and_then(|u| u.host_str().map(str::to_owned))
+    {
+        Some(h) => h,
+        None => return *UNREACHABLE_REQUEST_ERROR,
+    };
+    match host_resolves_locally_cached(&host, timeout).await {
+        LocalDnsState::NxDomain => {
+            #[cfg(not(feature = "decentralized"))]
+            chrome_nxdomain_cache().insert(host);
+            *DNS_RESOLVE_ERROR
+        }
+        LocalDnsState::Resolved | LocalDnsState::TimedOut => *UNREACHABLE_REQUEST_ERROR,
+    }
+}
+
 /// Pair a chrome rendered-error tunnel/proxy CONNECT failure with an
 /// independent local DNS lookup. Chrome-side counterpart to
 /// [`confirm_tunnel_failure_with_local_dns`] — same two-signal contract:
@@ -4464,12 +4494,40 @@ impl Page {
         cache_policy: &Option<BasicCachePolicy>,
         cache_namespace: Option<&str>,
     ) -> Self {
+        Self::new_page_with_cache_engine(
+            url,
+            client,
+            cache_options,
+            cache_policy,
+            cache_namespace,
+            None,
+        )
+        .await
+    }
+
+    /// Same as [`new_page_with_cache`](Self::new_page_with_cache) but also
+    /// consults an optional in-process
+    /// [`HttpFetchEngine`](crate::fetch_engine::HttpFetchEngine): when
+    /// installed and [`should_fetch`](crate::fetch_engine::HttpFetchEngine::should_fetch)
+    /// accepts the URL, the body fetch is served by the engine (still
+    /// wrapped in spider's cache / retry / watchdog machinery). Passing
+    /// `None` is identical to [`new_page_with_cache`](Self::new_page_with_cache).
+    #[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]
+    pub async fn new_page_with_cache_engine(
+        url: &str,
+        client: &Client,
+        cache_options: Option<CacheOptions>,
+        cache_policy: &Option<BasicCachePolicy>,
+        cache_namespace: Option<&str>,
+        engine: Option<crate::fetch_engine::EngineFetchCtx<'_>>,
+    ) -> Self {
         let page_resource: PageResponse = crate::utils::fetch_page_html_raw_cached(
             url,
             client,
             cache_options,
             cache_policy,
             cache_namespace,
+            engine,
         )
         .await;
 
@@ -4662,8 +4720,61 @@ impl Page {
         links_pages: &mut Option<hashbrown::HashSet<A>>,
         http_first_byte_args: (Option<std::time::Duration>, Option<std::time::Duration>),
     ) -> Self {
+        Self::new_page_streaming_engine(
+            url,
+            client,
+            only_html,
+            selectors,
+            external_domains_caseless,
+            r_settings,
+            map,
+            ssg_map,
+            prior_domain,
+            domain_parsed,
+            links_pages,
+            http_first_byte_args,
+            None,
+        )
+        .await
+    }
+
+    /// Same as [`new_page_streaming`](Self::new_page_streaming) but also
+    /// consults an optional in-process
+    /// [`HttpFetchEngine`](crate::fetch_engine::HttpFetchEngine): when
+    /// installed and [`should_fetch`](crate::fetch_engine::HttpFetchEngine::should_fetch)
+    /// accepts the URL, the body fetch (and inline link extraction) is
+    /// served by the engine, still wrapped in spider's watchdog / retry /
+    /// hedge machinery. Passing `None` is identical to
+    /// [`new_page_streaming`](Self::new_page_streaming).
+    #[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]
+    pub async fn new_page_streaming_engine<
+        A: PartialEq
+            + Eq
+            + Sync
+            + Send
+            + Clone
+            + Default
+            + std::hash::Hash
+            + From<String>
+            + for<'a> From<&'a str>,
+    >(
+        url: &str,
+        client: &Client,
+        only_html: bool,
+        selectors: &mut RelativeSelectors,
+        external_domains_caseless: &Arc<HashSet<CaseInsensitiveString>>,
+        r_settings: &PageLinkBuildSettings,
+        map: &mut hashbrown::HashSet<A>,
+        ssg_map: Option<&mut hashbrown::HashSet<A>>,
+        prior_domain: &Option<Box<Url>>,
+        domain_parsed: &mut Option<Box<Url>>,
+        links_pages: &mut Option<hashbrown::HashSet<A>>,
+        http_first_byte_args: (Option<std::time::Duration>, Option<std::time::Duration>),
+        engine: Option<crate::fetch_engine::EngineFetchCtx<'_>>,
+    ) -> Self {
         let (http_first_byte_timeout, http_first_byte_timeout_jitter) = http_first_byte_args;
         use crate::utils::{
+            handle_engine_response_bytes, handle_engine_response_bytes_writer,
             handle_response_bytes, handle_response_bytes_writer, modify_selectors,
             AllowedDomainTypes,
         };
@@ -4689,13 +4800,258 @@ impl Page {
         // synthesize the same `524 GATEWAY_TIMEOUT` PageResponse the
         // primary HTTP fetch path produces (`build_first_byte_timeout_page_response`)
         // so the caller's retry code rotates the proxy.
+        // Route this URL through the in-process fetch engine when one is
+        // installed and it accepts the URL; otherwise fall through to the
+        // reqwest streaming path unchanged. The engine arms mirror the
+        // reqwest arms below (streaming link-extraction on a parseable
+        // HTML body, buffered handling otherwise, categorized error
+        // mapping, and the same synthetic `524` on a first-byte timeout),
+        // sourced from an `EngineResponse` instead of a `reqwest::Response`
+        // — so spider's watchdog / retry / cache / hedge machinery wraps
+        // the engine identically.
+        let engine_ctx = engine.filter(|ctx| ctx.engine.should_fetch(url));
+
+        let mut page_response: PageResponse = if let Some(ctx) = engine_ctx {
+            let req = crate::fetch_engine::EngineRequest {
+                url,
+                method: crate::fetch_engine::EngineMethod::Get,
+                configuration: ctx.configuration,
+                only_html,
+                attempt: 0,
+                conditional_headers: None,
+            };
+            match crate::utils::timeout_first_byte(
+                ctx.engine.fetch(req),
+                http_first_byte_timeout,
+                http_first_byte_timeout_jitter,
+            )
+            .await
+            {
+                crate::utils::HttpSendOutcome::FirstByteTimeout(_) => {
+                    #[cfg(feature = "balance")]
+                    {
+                        crate::utils::vitals::request_error();
+                        crate::utils::vitals::request_end();
+                    }
+                    return build(
+                        url,
+                        crate::utils::build_first_byte_timeout_page_response(url),
+                    );
+                }
+                crate::utils::HttpSendOutcome::Ok(Err(engine_err)) => {
+                    #[cfg(feature = "balance")]
+                    crate::utils::vitals::request_error();
+                    crate::utils::build_engine_error_page_response(url, engine_err).await
+                }
+                crate::utils::HttpSendOutcome::Ok(Ok(resp))
+                    if crate::utils::valid_parsing_status_code(resp.status_code)
+                        && !crate::utils::block_streaming_headers(&resp.headers, only_html) =>
+                {
+                    let cell = if r_settings.ssg_build {
+                        Some(tokio::sync::OnceCell::new())
+                    } else {
+                        None
+                    };
+
+                    let base_input_url = tokio::sync::OnceCell::new();
+
+                    let (encoding, adjust_charset_on_meta_tag) =
+                        match get_charset_from_content_type(&resp.headers) {
+                            Some(h) => (h, false),
+                            _ => (AsciiCompatibleEncoding::utf_8(), true),
+                        };
+
+                    // Post-redirect URL from the engine (`final_url`), or the
+                    // requested URL when there was no redirect.
+                    let target_url_owned: String =
+                        resp.final_url.clone().unwrap_or_else(|| url.to_string());
+                    let target_url = target_url_owned.as_str();
+                    let declared_len = resp.declared_content_length;
+
+                    // handle initial redirects
+                    if ssg_map.is_some() && url != target_url && !exact_url_match(url, target_url) {
+                        let mut url = Box::new(CaseInsensitiveString::new(&url));
+
+                        modify_selectors(
+                            prior_domain,
+                            target_url,
+                            domain_parsed,
+                            &mut url,
+                            selectors,
+                            AllowedDomainTypes::new(r_settings.subdomains, r_settings.tld),
+                        );
+                    };
+
+                    let base = if domain_parsed.is_none() {
+                        prior_domain
+                    } else {
+                        domain_parsed
+                    };
+
+                    let original_page = Url::parse(url).ok();
+                    let xml_file = target_url.ends_with(".xml");
+
+                    let parent_host = &selectors.1[0];
+                    let parent_host_scheme = &selectors.1[1];
+                    let base_input_domain = &selectors.2;
+                    let sub_matcher = &selectors.0;
+
+                    let element_content_handlers = build_link_extract_handlers(
+                        LinkExtractCtx {
+                            selectors,
+                            external_domains_caseless,
+                            map,
+                            links_pages,
+                            base_input_url: &base_input_url,
+                            base: base.as_deref(),
+                            original_page: original_page.as_ref(),
+                            ssg_raw_src_cell: if r_settings.ssg_build && !r_settings.skip_links {
+                                cell.as_ref()
+                            } else {
+                                None
+                            },
+                            ssg_resolved_path_cell: None,
+                            xml_file,
+                            full_resources: r_settings.full_resources,
+                            skip_links: r_settings.skip_links,
+                        },
+                        &mut meta_title,
+                        &mut meta_description,
+                        &mut meta_og_image,
+                    );
+
+                    let settings = lol_html::send::Settings {
+                        element_content_handlers,
+                        adjust_charset_on_meta_tag,
+                        encoding,
+                        ..lol_html::send::Settings::new_for_handler_types()
+                    };
+
+                    let mut rewriter =
+                        lol_html::send::HtmlRewriter::new(settings, |_c: &[u8]| {});
+
+                    let mut collected_bytes = match declared_len {
+                        Some(cap) if cap > MAX_CONTENT_LENGTH => {
+                            log::warn!("{url} Content-Length {cap} exceeds 2 GB limit, rejecting");
+                            Vec::new()
+                        }
+                        Some(cap) if cap > 0 => {
+                            Vec::with_capacity((cap as usize).min(MAX_PREALLOC))
+                        }
+                        _ => Vec::with_capacity(MAX_PRE_ALLOCATED_HTML_PAGE_SIZE_USIZE),
+                    };
+
+                    let mut response = handle_engine_response_bytes_writer(
+                        resp,
+                        url,
+                        only_html,
+                        &mut rewriter,
+                        &mut collected_bytes,
+                    )
+                    .await;
+
+                    let rewrite_error = response.1;
+
+                    if !rewrite_error {
+                        let _ = rewriter.end();
+                    }
+
+                    if r_settings.normalize {
+                        response.0.signature = Some(hash_html(&collected_bytes).await);
+                    }
+
+                    response.0.content = if collected_bytes.is_empty() {
+                        None
+                    } else {
+                        Some(collected_bytes)
+                    };
+
+                    if r_settings.ssg_build {
+                        if let Some(ssg_map) = ssg_map {
+                            if let Some(cell) = &cell {
+                                if let Some(source) = cell.get() {
+                                    if let Some(url_base) = &base {
+                                        let build_ssg_path = convert_abs_path(url_base, source);
+                                        let build_page =
+                                            Page::new_page(build_ssg_path.as_str(), client).await;
+
+                                        for cap in SSG_CAPTURE
+                                            .captures_iter(build_page.get_html_bytes_u8())
+                                        {
+                                            if let Some(matched) = cap.get(1) {
+                                                let href = auto_encode_bytes(matched.as_bytes())
+                                                    .replace(r#"\u002F"#, "/");
+
+                                                let last_segment =
+                                                    crate::utils::get_last_segment(&href);
+
+                                                if !(last_segment.starts_with("[")
+                                                    && last_segment.ends_with("]"))
+                                                {
+                                                    let base = if relative_directory_url(&href)
+                                                        || base.is_none()
+                                                    {
+                                                        original_page.as_ref()
+                                                    } else {
+                                                        base.as_deref()
+                                                    };
+                                                    let base = if base_input_url.initialized() {
+                                                        base_input_url.get()
+                                                    } else {
+                                                        base
+                                                    };
+                                                    push_link(
+                                                        &base,
+                                                        &href,
+                                                        ssg_map,
+                                                        &selectors.0,
+                                                        parent_host,
+                                                        parent_host_scheme,
+                                                        base_input_domain,
+                                                        sub_matcher,
+                                                        external_domains_caseless,
+                                                        &mut None,
+                                                    );
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    response.0
+                }
+                crate::utils::HttpSendOutcome::Ok(Ok(resp)) => {
+                    let pr = handle_engine_response_bytes(resp, url, only_html).await;
+                    if pr.content_truncated {
+                        log::warn!("Response truncated for {url}, retrying once");
+                        let retry_req = crate::fetch_engine::EngineRequest {
+                            url,
+                            method: crate::fetch_engine::EngineMethod::Get,
+                            configuration: ctx.configuration,
+                            only_html,
+                            attempt: 1,
+                            conditional_headers: None,
+                        };
+                        match ctx.engine.fetch(retry_req).await {
+                            Ok(resp2) => handle_engine_response_bytes(resp2, url, only_html).await,
+                            Err(_) => pr,
+                        }
+                    } else {
+                        pr
+                    }
+                }
+            }
+        } else {
         let send_outcome = crate::utils::timeout_first_byte(
             client.get(url).send(),
             http_first_byte_timeout,
             http_first_byte_timeout_jitter,
         )
         .await;
-        let mut page_response: PageResponse = match send_outcome {
+        match send_outcome {
             crate::utils::HttpSendOutcome::FirstByteTimeout(_) => {
                 // Balance the `vitals::request_start` counter that
                 // fires above before any early return — otherwise
@@ -4918,6 +5274,7 @@ impl Page {
                     crate::utils::build_error_page_response(url, err).await
                 }
             },
+        }
         };
 
         #[cfg(feature = "balance")]

--- a/spider/src/page.rs
+++ b/spider/src/page.rs
@@ -4927,8 +4927,7 @@ impl Page {
                         ..lol_html::send::Settings::new_for_handler_types()
                     };
 
-                    let mut rewriter =
-                        lol_html::send::HtmlRewriter::new(settings, |_c: &[u8]| {});
+                    let mut rewriter = lol_html::send::HtmlRewriter::new(settings, |_c: &[u8]| {});
 
                     let mut collected_bytes = match declared_len {
                         Some(cap) if cap > MAX_CONTENT_LENGTH => {
@@ -5045,196 +5044,206 @@ impl Page {
                 }
             }
         } else {
-        let send_outcome = crate::utils::timeout_first_byte(
-            client.get(url).send(),
-            http_first_byte_timeout,
-            http_first_byte_timeout_jitter,
-        )
-        .await;
-        match send_outcome {
-            crate::utils::HttpSendOutcome::FirstByteTimeout(_) => {
-                // Balance the `vitals::request_start` counter that
-                // fires above before any early return — otherwise
-                // `REQUESTS_IN_FLIGHT` leaks indefinitely on every
-                // first-byte timeout, breaking the scaler's signal.
-                #[cfg(feature = "balance")]
-                {
-                    crate::utils::vitals::request_error();
-                    crate::utils::vitals::request_end();
+            let send_outcome = crate::utils::timeout_first_byte(
+                client.get(url).send(),
+                http_first_byte_timeout,
+                http_first_byte_timeout_jitter,
+            )
+            .await;
+            match send_outcome {
+                crate::utils::HttpSendOutcome::FirstByteTimeout(_) => {
+                    // Balance the `vitals::request_start` counter that
+                    // fires above before any early return — otherwise
+                    // `REQUESTS_IN_FLIGHT` leaks indefinitely on every
+                    // first-byte timeout, breaking the scaler's signal.
+                    #[cfg(feature = "balance")]
+                    {
+                        crate::utils::vitals::request_error();
+                        crate::utils::vitals::request_end();
+                    }
+                    return build(
+                        url,
+                        crate::utils::build_first_byte_timeout_page_response(url),
+                    );
                 }
-                return build(
-                    url,
-                    crate::utils::build_first_byte_timeout_page_response(url),
-                );
-            }
-            crate::utils::HttpSendOutcome::Ok(send_result) => match send_result {
-                Ok(res)
-                    if crate::utils::valid_parsing_status(&res)
-                        && !crate::utils::block_streaming(&res, only_html) =>
-                {
-                    let cell = if r_settings.ssg_build {
-                        Some(tokio::sync::OnceCell::new())
-                    } else {
-                        None
-                    };
-
-                    let base_input_url = tokio::sync::OnceCell::new();
-
-                    let (encoding, adjust_charset_on_meta_tag) =
-                        match get_charset_from_content_type(res.headers()) {
-                            Some(h) => (h, false),
-                            _ => (AsciiCompatibleEncoding::utf_8(), true),
+                crate::utils::HttpSendOutcome::Ok(send_result) => match send_result {
+                    Ok(res)
+                        if crate::utils::valid_parsing_status(&res)
+                            && !crate::utils::block_streaming(&res, only_html) =>
+                    {
+                        let cell = if r_settings.ssg_build {
+                            Some(tokio::sync::OnceCell::new())
+                        } else {
+                            None
                         };
 
-                    let target_url = res.url().as_str();
+                        let base_input_url = tokio::sync::OnceCell::new();
 
-                    // handle initial redirects
-                    if ssg_map.is_some() && url != target_url && !exact_url_match(url, target_url) {
-                        let mut url = Box::new(CaseInsensitiveString::new(&url));
+                        let (encoding, adjust_charset_on_meta_tag) =
+                            match get_charset_from_content_type(res.headers()) {
+                                Some(h) => (h, false),
+                                _ => (AsciiCompatibleEncoding::utf_8(), true),
+                            };
 
-                        modify_selectors(
-                            prior_domain,
-                            target_url,
-                            domain_parsed,
-                            &mut url,
-                            selectors,
-                            AllowedDomainTypes::new(r_settings.subdomains, r_settings.tld),
-                        );
-                    };
+                        let target_url = res.url().as_str();
 
-                    let base = if domain_parsed.is_none() {
-                        prior_domain
-                    } else {
-                        domain_parsed
-                    };
+                        // handle initial redirects
+                        if ssg_map.is_some()
+                            && url != target_url
+                            && !exact_url_match(url, target_url)
+                        {
+                            let mut url = Box::new(CaseInsensitiveString::new(&url));
 
-                    let original_page = Url::parse(url).ok();
-                    let xml_file = target_url.ends_with(".xml");
+                            modify_selectors(
+                                prior_domain,
+                                target_url,
+                                domain_parsed,
+                                &mut url,
+                                selectors,
+                                AllowedDomainTypes::new(r_settings.subdomains, r_settings.tld),
+                            );
+                        };
 
-                    // Locals used by the post-rewriter SSG block below for
-                    // its own `push_link` calls — kept around even after the
-                    // helper consumes its own copy of the same projections.
-                    let parent_host = &selectors.1[0];
-                    let parent_host_scheme = &selectors.1[1];
-                    let base_input_domain = &selectors.2;
-                    let sub_matcher = &selectors.0;
+                        let base = if domain_parsed.is_none() {
+                            prior_domain
+                        } else {
+                            domain_parsed
+                        };
 
-                    let element_content_handlers = build_link_extract_handlers(
-                        LinkExtractCtx {
-                            selectors,
-                            external_domains_caseless,
-                            map,
-                            links_pages,
-                            base_input_url: &base_input_url,
-                            base: base.as_deref(),
-                            original_page: original_page.as_ref(),
-                            ssg_raw_src_cell: if r_settings.ssg_build && !r_settings.skip_links {
-                                cell.as_ref()
-                            } else {
-                                None
+                        let original_page = Url::parse(url).ok();
+                        let xml_file = target_url.ends_with(".xml");
+
+                        // Locals used by the post-rewriter SSG block below for
+                        // its own `push_link` calls — kept around even after the
+                        // helper consumes its own copy of the same projections.
+                        let parent_host = &selectors.1[0];
+                        let parent_host_scheme = &selectors.1[1];
+                        let base_input_domain = &selectors.2;
+                        let sub_matcher = &selectors.0;
+
+                        let element_content_handlers = build_link_extract_handlers(
+                            LinkExtractCtx {
+                                selectors,
+                                external_domains_caseless,
+                                map,
+                                links_pages,
+                                base_input_url: &base_input_url,
+                                base: base.as_deref(),
+                                original_page: original_page.as_ref(),
+                                ssg_raw_src_cell: if r_settings.ssg_build && !r_settings.skip_links
+                                {
+                                    cell.as_ref()
+                                } else {
+                                    None
+                                },
+                                ssg_resolved_path_cell: None,
+                                xml_file,
+                                full_resources: r_settings.full_resources,
+                                skip_links: r_settings.skip_links,
                             },
-                            ssg_resolved_path_cell: None,
-                            xml_file,
-                            full_resources: r_settings.full_resources,
-                            skip_links: r_settings.skip_links,
-                        },
-                        &mut meta_title,
-                        &mut meta_description,
-                        &mut meta_og_image,
-                    );
+                            &mut meta_title,
+                            &mut meta_description,
+                            &mut meta_og_image,
+                        );
 
-                    let settings = lol_html::send::Settings {
-                        element_content_handlers,
-                        adjust_charset_on_meta_tag,
-                        encoding,
-                        ..lol_html::send::Settings::new_for_handler_types()
-                    };
+                        let settings = lol_html::send::Settings {
+                            element_content_handlers,
+                            adjust_charset_on_meta_tag,
+                            encoding,
+                            ..lol_html::send::Settings::new_for_handler_types()
+                        };
 
-                    let mut rewriter = lol_html::send::HtmlRewriter::new(settings, |_c: &[u8]| {});
+                        let mut rewriter =
+                            lol_html::send::HtmlRewriter::new(settings, |_c: &[u8]| {});
 
-                    let mut collected_bytes = match res.content_length() {
-                        Some(cap) if cap > MAX_CONTENT_LENGTH => {
-                            log::warn!("{url} Content-Length {cap} exceeds 2 GB limit, rejecting");
-                            Vec::new()
+                        let mut collected_bytes = match res.content_length() {
+                            Some(cap) if cap > MAX_CONTENT_LENGTH => {
+                                log::warn!(
+                                    "{url} Content-Length {cap} exceeds 2 GB limit, rejecting"
+                                );
+                                Vec::new()
+                            }
+                            Some(cap) if cap > 0 => {
+                                Vec::with_capacity((cap as usize).min(MAX_PREALLOC))
+                            }
+                            _ => Vec::with_capacity(MAX_PRE_ALLOCATED_HTML_PAGE_SIZE_USIZE),
+                        };
+
+                        let mut response = handle_response_bytes_writer(
+                            res,
+                            url,
+                            only_html,
+                            &mut rewriter,
+                            &mut collected_bytes,
+                        )
+                        .await;
+
+                        let rewrite_error = response.1;
+
+                        if !rewrite_error {
+                            let _ = rewriter.end();
                         }
-                        Some(cap) if cap > 0 => {
-                            Vec::with_capacity((cap as usize).min(MAX_PREALLOC))
+
+                        if r_settings.normalize {
+                            response.0.signature = Some(hash_html(&collected_bytes).await);
                         }
-                        _ => Vec::with_capacity(MAX_PRE_ALLOCATED_HTML_PAGE_SIZE_USIZE),
-                    };
 
-                    let mut response = handle_response_bytes_writer(
-                        res,
-                        url,
-                        only_html,
-                        &mut rewriter,
-                        &mut collected_bytes,
-                    )
-                    .await;
+                        response.0.content = if collected_bytes.is_empty() {
+                            None
+                        } else {
+                            Some(collected_bytes)
+                        };
 
-                    let rewrite_error = response.1;
+                        if r_settings.ssg_build {
+                            if let Some(ssg_map) = ssg_map {
+                                if let Some(cell) = &cell {
+                                    if let Some(source) = cell.get() {
+                                        if let Some(url_base) = &base {
+                                            let build_ssg_path = convert_abs_path(url_base, source);
+                                            let build_page =
+                                                Page::new_page(build_ssg_path.as_str(), client)
+                                                    .await;
 
-                    if !rewrite_error {
-                        let _ = rewriter.end();
-                    }
+                                            for cap in SSG_CAPTURE
+                                                .captures_iter(build_page.get_html_bytes_u8())
+                                            {
+                                                if let Some(matched) = cap.get(1) {
+                                                    let href =
+                                                        auto_encode_bytes(matched.as_bytes())
+                                                            .replace(r#"\u002F"#, "/");
 
-                    if r_settings.normalize {
-                        response.0.signature = Some(hash_html(&collected_bytes).await);
-                    }
+                                                    let last_segment =
+                                                        crate::utils::get_last_segment(&href);
 
-                    response.0.content = if collected_bytes.is_empty() {
-                        None
-                    } else {
-                        Some(collected_bytes)
-                    };
-
-                    if r_settings.ssg_build {
-                        if let Some(ssg_map) = ssg_map {
-                            if let Some(cell) = &cell {
-                                if let Some(source) = cell.get() {
-                                    if let Some(url_base) = &base {
-                                        let build_ssg_path = convert_abs_path(url_base, source);
-                                        let build_page =
-                                            Page::new_page(build_ssg_path.as_str(), client).await;
-
-                                        for cap in SSG_CAPTURE
-                                            .captures_iter(build_page.get_html_bytes_u8())
-                                        {
-                                            if let Some(matched) = cap.get(1) {
-                                                let href = auto_encode_bytes(matched.as_bytes())
-                                                    .replace(r#"\u002F"#, "/");
-
-                                                let last_segment =
-                                                    crate::utils::get_last_segment(&href);
-
-                                                // we can pass in a static map of the dynamic SSG routes pre-hand, custom API endpoint to seed, or etc later.
-                                                if !(last_segment.starts_with("[")
-                                                    && last_segment.ends_with("]"))
-                                                {
-                                                    let base = if relative_directory_url(&href)
-                                                        || base.is_none()
+                                                    // we can pass in a static map of the dynamic SSG routes pre-hand, custom API endpoint to seed, or etc later.
+                                                    if !(last_segment.starts_with("[")
+                                                        && last_segment.ends_with("]"))
                                                     {
-                                                        original_page.as_ref()
-                                                    } else {
-                                                        base.as_deref()
-                                                    };
-                                                    let base = if base_input_url.initialized() {
-                                                        base_input_url.get()
-                                                    } else {
-                                                        base
-                                                    };
-                                                    push_link(
-                                                        &base,
-                                                        &href,
-                                                        ssg_map,
-                                                        &selectors.0,
-                                                        parent_host,
-                                                        parent_host_scheme,
-                                                        base_input_domain,
-                                                        sub_matcher,
-                                                        external_domains_caseless,
-                                                        &mut None,
-                                                    );
+                                                        let base = if relative_directory_url(&href)
+                                                            || base.is_none()
+                                                        {
+                                                            original_page.as_ref()
+                                                        } else {
+                                                            base.as_deref()
+                                                        };
+                                                        let base = if base_input_url.initialized() {
+                                                            base_input_url.get()
+                                                        } else {
+                                                            base
+                                                        };
+                                                        push_link(
+                                                            &base,
+                                                            &href,
+                                                            ssg_map,
+                                                            &selectors.0,
+                                                            parent_host,
+                                                            parent_host_scheme,
+                                                            base_input_domain,
+                                                            sub_matcher,
+                                                            external_domains_caseless,
+                                                            &mut None,
+                                                        );
+                                                    }
                                                 }
                                             }
                                         }
@@ -5242,39 +5251,38 @@ impl Page {
                                 }
                             }
                         }
-                    }
 
-                    response.0
-                }
-                Ok(res) => {
-                    let pr = handle_response_bytes(res, url, only_html).await;
-                    if pr.content_truncated {
-                        log::warn!("Response truncated for {url}, retrying once");
-                        match client.get(url).send().await {
-                            Ok(res2) => handle_response_bytes(res2, url, only_html).await,
-                            Err(_) => pr,
+                        response.0
+                    }
+                    Ok(res) => {
+                        let pr = handle_response_bytes(res, url, only_html).await;
+                        if pr.content_truncated {
+                            log::warn!("Response truncated for {url}, retrying once");
+                            match client.get(url).send().await {
+                                Ok(res2) => handle_response_bytes(res2, url, only_html).await,
+                                Err(_) => pr,
+                            }
+                        } else {
+                            pr
                         }
-                    } else {
-                        pr
                     }
-                }
-                Err(err) => {
-                    // Pre-v2.51.176: this path handled errors inline as
-                    // `page_response.status_code = get_error_http_status_code(&err)`
-                    // and skipped the async two-signal confirmation. For NXDOMAIN
-                    // through a proxy, that meant tunnel failures stayed at the
-                    // 503 catch-all (retryable) and the retry loop ran for
-                    // minutes per host — even though `crawl()` /
-                    // `crawl_concurrent` is the most common entry point. Now
-                    // delegated to `build_error_page_response` so the two-signal
-                    // confirmation runs identically across every fetch path.
-                    #[cfg(feature = "balance")]
-                    crate::utils::vitals::request_error();
+                    Err(err) => {
+                        // Pre-v2.51.176: this path handled errors inline as
+                        // `page_response.status_code = get_error_http_status_code(&err)`
+                        // and skipped the async two-signal confirmation. For NXDOMAIN
+                        // through a proxy, that meant tunnel failures stayed at the
+                        // 503 catch-all (retryable) and the retry loop ran for
+                        // minutes per host — even though `crawl()` /
+                        // `crawl_concurrent` is the most common entry point. Now
+                        // delegated to `build_error_page_response` so the two-signal
+                        // confirmation runs identically across every fetch path.
+                        #[cfg(feature = "balance")]
+                        crate::utils::vitals::request_error();
 
-                    crate::utils::build_error_page_response(url, err).await
-                }
-            },
-        }
+                        crate::utils::build_error_page_response(url, err).await
+                    }
+                },
+            }
         };
 
         #[cfg(feature = "balance")]

--- a/spider/src/utils/mod.rs
+++ b/spider/src/utils/mod.rs
@@ -6193,19 +6193,35 @@ impl Utf8StreamValidator {
 
 /// Block streaming
 pub(crate) fn block_streaming(res: &Response, only_html: bool) -> bool {
-    let mut block_streaming = false;
+    block_streaming_headers(res.headers(), only_html)
+}
 
+/// Headers-only variant of [`block_streaming`], so producers that hold a
+/// [`reqwest::header::HeaderMap`] directly (e.g. the in-process fetch
+/// engine path) get the identical "should we skip streaming this body"
+/// decision without a `Response`.
+pub(crate) fn block_streaming_headers(
+    headers: &reqwest::header::HeaderMap,
+    only_html: bool,
+) -> bool {
     if only_html {
-        if let Some(content_type) = res.headers().get(crate::client::header::CONTENT_TYPE) {
+        if let Some(content_type) = headers.get(reqwest::header::CONTENT_TYPE) {
             if let Ok(content_type_str) = content_type.to_str() {
                 if IGNORE_CONTENT_TYPES.contains(content_type_str) {
-                    block_streaming = true;
+                    return true;
                 }
             }
         }
     }
 
-    block_streaming
+    false
+}
+
+/// Status-only variant of [`valid_parsing_status`] for producers that
+/// hold a [`StatusCode`] directly (e.g. the in-process fetch engine
+/// path). Kept in lockstep with [`valid_parsing_status`].
+pub(crate) fn valid_parsing_status_code(status: StatusCode) -> bool {
+    status.is_success() || status == StatusCode::NOT_FOUND
 }
 
 /// Handle the response bytes
@@ -6572,6 +6588,282 @@ pub(crate) async fn build_error_page_response(target_url: &str, err: RequestErro
     page_response
 }
 
+/// Build a [`PageResponse`] from a completed
+/// [`crate::fetch_engine::EngineResponse`], applying the same size caps,
+/// UTF-8 validation, and anti-bot detection spider applies to a streamed
+/// reqwest response. The engine returns a fully-decoded body, so the
+/// per-chunk idle timeout is the engine's own concern; everything visible
+/// at the spider boundary (`MAX_SIZE_BYTES` cap, 2 GB `Content-Length`
+/// reject, mismatch → `content_truncated`, binary short-circuit, UTF-8
+/// verdict, anti-bot classification) is reproduced here so the engine and
+/// reqwest paths stay in parity into [`crate::page::build`].
+pub async fn handle_engine_response_bytes(
+    resp: crate::fetch_engine::EngineResponse,
+    target_url: &str,
+    only_html: bool,
+) -> PageResponse {
+    let crate::fetch_engine::EngineResponse {
+        status_code,
+        final_url,
+        headers,
+        #[cfg(feature = "remote_addr")]
+        remote_addr,
+        #[cfg(feature = "cookies")]
+        response_cookies,
+        body,
+        declared_content_length,
+        anti_bot_tech: engine_anti_bot,
+        served: _served,
+    } = resp;
+
+    // Redirect detection parity: set `final_url` only when it differs from
+    // the requested URL (mirrors `res.url() != target_url`).
+    let rd = match final_url {
+        Some(ref u) if u != target_url => Some(u.clone()),
+        _ => None,
+    };
+
+    let limit = *MAX_SIZE_BYTES;
+
+    // Upfront oversize reject on the declared length, mirroring the
+    // reqwest path's `current_size > limit` guard (returns no content).
+    if limit > 0 {
+        if let Some(cap) = declared_content_length {
+            if cap as usize > limit {
+                let anti_bot_tech = engine_anti_bot.unwrap_or_else(|| {
+                    detect_anti_bot_tech_response(
+                        target_url,
+                        &HeaderSource::HeaderMap(&headers),
+                        &[],
+                        None,
+                    )
+                });
+                return PageResponse {
+                    headers: Some(headers),
+                    #[cfg(feature = "remote_addr")]
+                    remote_addr,
+                    #[cfg(feature = "cookies")]
+                    cookies: response_cookies,
+                    content: None,
+                    final_url: rd,
+                    status_code,
+                    anti_bot_tech,
+                    ..Default::default()
+                };
+            }
+        }
+    }
+
+    // Reject a body whose declared length blows the 2 GB ceiling.
+    if let Some(cap) = declared_content_length {
+        if cap > MAX_CONTENT_LENGTH {
+            log::warn!("{target_url} Content-Length {cap} exceeds 2 GB limit, rejecting");
+            return PageResponse {
+                headers: Some(headers),
+                #[cfg(feature = "remote_addr")]
+                remote_addr,
+                #[cfg(feature = "cookies")]
+                cookies: response_cookies,
+                content: None,
+                final_url: rd,
+                status_code,
+                anti_bot_tech: AntiBotTech::default(),
+                ..Default::default()
+            };
+        }
+    }
+
+    let mut content: Option<Vec<u8>> = None;
+    let mut anti_bot_tech = AntiBotTech::default();
+    let mut content_truncated = false;
+    let mut is_valid_utf8: Option<bool> = None;
+
+    // Binary short-circuit mirrors the reqwest path: on `only_html`, a
+    // binary leading run is dropped (empty body kept, no content stored
+    // beyond the empty vec) — the reqwest loop breaks before appending.
+    let binary = only_html && is_binary_body(&body);
+    let mut data = if binary { Vec::new() } else { body };
+
+    // Oversize → keep bytes up to the limit and flag truncation, matching
+    // the streaming loop's `data.len() + text.len() > limit` behavior.
+    if limit > 0 && data.len() > limit {
+        data.truncate(limit);
+        content_truncated = true;
+    }
+
+    // Content-Length mismatch (fewer bytes than promised) → truncated.
+    if !content_truncated && !binary {
+        if let Some(expected) = declared_content_length {
+            if (data.len() as u64) < expected {
+                log::warn!(
+                    "Content-Length mismatch for {target_url}: expected {expected} bytes, received {} bytes",
+                    data.len()
+                );
+                content_truncated = true;
+            }
+        }
+    }
+
+    if content_truncated && data.is_empty() {
+        log::warn!("discarding empty truncated response for {target_url}");
+    } else {
+        anti_bot_tech = engine_anti_bot.unwrap_or_else(|| {
+            detect_anti_bot_tech_response(
+                target_url,
+                &HeaderSource::HeaderMap(&headers),
+                &data,
+                None,
+            )
+        });
+        let mut utf8_state = Utf8StreamValidator::default();
+        utf8_state.feed(&data);
+        is_valid_utf8 = utf8_state.finish(Some(&data));
+        content = Some(data);
+    }
+
+    PageResponse {
+        headers: Some(headers),
+        #[cfg(feature = "remote_addr")]
+        remote_addr,
+        #[cfg(feature = "cookies")]
+        cookies: response_cookies,
+        is_valid_utf8,
+        content,
+        final_url: rd,
+        status_code,
+        anti_bot_tech,
+        content_truncated,
+        ..Default::default()
+    }
+}
+
+/// Engine-path counterpart to [`handle_response_bytes_writer`]: feed the
+/// engine's fully-decoded body through the streaming link-extraction
+/// rewriter in a single `write`, then apply the same UTF-8 /
+/// anti-bot / truncation semantics. Link extraction is
+/// chunk-boundary-independent, so a single write yields identical links.
+pub async fn handle_engine_response_bytes_writer<'h, O>(
+    resp: crate::fetch_engine::EngineResponse,
+    target_url: &str,
+    only_html: bool,
+    rewriter: &mut HtmlRewriter<'h, O>,
+    collected_bytes: &mut Vec<u8>,
+) -> (PageResponse, bool)
+where
+    O: OutputSink + Send + 'static,
+{
+    let crate::fetch_engine::EngineResponse {
+        status_code,
+        final_url,
+        headers,
+        #[cfg(feature = "remote_addr")]
+        remote_addr,
+        #[cfg(feature = "cookies")]
+        response_cookies,
+        body,
+        declared_content_length,
+        anti_bot_tech: engine_anti_bot,
+        served: _served,
+    } = resp;
+
+    let final_url = match final_url {
+        Some(ref u) if u != target_url => Some(u.clone()),
+        _ => None,
+    };
+
+    let mut anti_bot_tech = AntiBotTech::default();
+    let mut rewrite_error = false;
+    let mut content_truncated = false;
+    let mut utf8_state = Utf8StreamValidator::default();
+
+    let binary = only_html && is_binary_body(&body);
+
+    if !binary {
+        let limit = *MAX_SIZE_BYTES;
+        let mut data = body;
+
+        if limit > 0 && data.len() > limit {
+            data.truncate(limit);
+            content_truncated = true;
+        }
+
+        if !content_truncated {
+            if let Some(expected) = declared_content_length {
+                if (data.len() as u64) < expected {
+                    log::warn!(
+                        "Content-Length mismatch for {target_url}: expected {expected} bytes, received {} bytes",
+                        data.len()
+                    );
+                    content_truncated = true;
+                }
+            }
+        }
+
+        utf8_state.feed(&data);
+        if rewriter.write(&data).is_err() {
+            rewrite_error = true;
+        }
+        collected_bytes.extend_from_slice(&data);
+
+        anti_bot_tech = engine_anti_bot.unwrap_or_else(|| {
+            detect_anti_bot_tech_response(
+                target_url,
+                &HeaderSource::HeaderMap(&headers),
+                collected_bytes,
+                None,
+            )
+        });
+    }
+
+    (
+        PageResponse {
+            #[cfg(feature = "headers")]
+            headers: Some(headers),
+            #[cfg(feature = "remote_addr")]
+            remote_addr,
+            #[cfg(feature = "cookies")]
+            cookies: response_cookies,
+            is_valid_utf8: utf8_state.finish(Some(&collected_bytes[..])),
+            final_url,
+            status_code,
+            anti_bot_tech,
+            content_truncated,
+            ..Default::default()
+        },
+        rewrite_error,
+    )
+}
+
+/// Build an error [`PageResponse`] from a categorized
+/// [`crate::fetch_engine::EngineError`]. Mirrors
+/// [`build_error_page_response`] but is driven by the error category
+/// rather than a typed `reqwest::Error`: for a proxy tunnel failure it
+/// runs the same independent local-DNS confirmation (503 → 525 on
+/// NXDOMAIN, plus cross-transport cache insert); every other category
+/// maps directly onto its synthetic status. `error_for_status` stays
+/// `None`, so [`crate::page::build`] derives `should_retry` from the
+/// status alone — verified retry-equivalent to the reqwest path for the
+/// mapped 52x codes.
+pub(crate) async fn build_engine_error_page_response(
+    target_url: &str,
+    err: crate::fetch_engine::EngineError,
+) -> PageResponse {
+    log::info!("engine error fetching {target_url}: {err}");
+
+    let mut page_response = PageResponse::default();
+    page_response.status_code = if err.is_proxy_tunnel() {
+        crate::page::confirm_engine_tunnel_failure_with_local_dns(
+            target_url,
+            std::time::Duration::from_millis(1_500),
+        )
+        .await
+    } else {
+        err.to_status_code()
+    };
+    page_response.final_url = Some(target_url.to_string());
+    page_response
+}
+
 #[inline]
 /// Build a cached page response from HTML.
 pub(crate) fn build_cached_html_page_response(target_url: &str, html: &str) -> PageResponse {
@@ -6608,6 +6900,7 @@ async fn fetch_page_html_raw_base(
     only_html: bool,
     first_byte_timeout: Option<Duration>,
     first_byte_jitter: Option<Duration>,
+    engine: Option<crate::fetch_engine::EngineFetchCtx<'_>>,
 ) -> PageResponse {
     // Cross-feature NXDOMAIN cache shortcircuit (v2.51.189). The same
     // bounded cache that backs the chrome `Page::new_base` fast-fail
@@ -6630,7 +6923,106 @@ async fn fetch_page_html_raw_base(
         only_html: bool,
         first_byte_timeout: Option<Duration>,
         first_byte_jitter: Option<Duration>,
+        engine: Option<crate::fetch_engine::EngineFetchCtx<'_>>,
     ) -> Result<PageResponse, RequestError> {
+        // In-process fetch-engine branch. Wraps the engine call in the
+        // SAME first-byte watchdog as the reqwest path, maps the engine's
+        // typed error onto spider's synthetic statuses, and — on a TLS
+        // handshake failure — runs the same scheme-flip / strip-`www`
+        // retry ladder the reqwest path runs below. Falls through to
+        // reqwest when no engine is installed or `should_fetch` declines
+        // this URL.
+        if let Some(ctx) = engine {
+            if ctx.engine.should_fetch(url) {
+                // One engine send wrapped in the first-byte watchdog.
+                // `Ok` is a spider `PageResponse` (success or synthetic
+                // timeout); `Err` is a raw engine error kept so the caller
+                // can decide whether to run the handshake retry ladder.
+                async fn engine_send(
+                    ctx: crate::fetch_engine::EngineFetchCtx<'_>,
+                    url: &str,
+                    only_html: bool,
+                    first_byte_timeout: Option<Duration>,
+                    first_byte_jitter: Option<Duration>,
+                ) -> Result<PageResponse, crate::fetch_engine::EngineError> {
+                    let req = crate::fetch_engine::EngineRequest {
+                        url,
+                        method: crate::fetch_engine::EngineMethod::Get,
+                        configuration: ctx.configuration,
+                        only_html,
+                        attempt: 0,
+                        conditional_headers: None,
+                    };
+                    match timeout_first_byte(
+                        ctx.engine.fetch(req),
+                        first_byte_timeout,
+                        first_byte_jitter,
+                    )
+                    .await
+                    {
+                        HttpSendOutcome::Ok(Ok(resp)) => {
+                            Ok(handle_engine_response_bytes(resp, url, only_html).await)
+                        }
+                        HttpSendOutcome::Ok(Err(e)) => Err(e),
+                        HttpSendOutcome::FirstByteTimeout(_) => {
+                            Ok(build_first_byte_timeout_page_response(url))
+                        }
+                    }
+                }
+
+                let pr = match engine_send(
+                    ctx,
+                    url,
+                    only_html,
+                    first_byte_timeout,
+                    first_byte_jitter,
+                )
+                .await
+                {
+                    Ok(pr) => pr,
+                    Err(e) if e.is_handshake_failure() => {
+                        if let Some(flipped) = flip_http_https(url) {
+                            log::info!(
+                                "TLS handshake failure (engine) for {url}; retrying with flipped scheme: {flipped}"
+                            );
+                            match engine_send(
+                                ctx,
+                                &flipped,
+                                only_html,
+                                first_byte_timeout,
+                                first_byte_jitter,
+                            )
+                            .await
+                            {
+                                Ok(pr) => pr,
+                                Err(e2) => build_engine_error_page_response(&flipped, e2).await,
+                            }
+                        } else if let Some(no_www) = strip_www(url) {
+                            log::info!(
+                                "TLS handshake failure (engine) for {url}; retrying without www: {no_www}"
+                            );
+                            match engine_send(
+                                ctx,
+                                &no_www,
+                                only_html,
+                                first_byte_timeout,
+                                first_byte_jitter,
+                            )
+                            .await
+                            {
+                                Ok(pr) => pr,
+                                Err(e2) => build_engine_error_page_response(&no_www, e2).await,
+                            }
+                        } else {
+                            build_engine_error_page_response(url, e).await
+                        }
+                    }
+                    Err(e) => build_engine_error_page_response(url, e).await,
+                };
+                return Ok(pr);
+            }
+        }
+
         // Generic future-wrapper — works across reqwest / wreq /
         // reqwest_middleware backends because the inner `?` propagates
         // each variant's own `RequestError` type alias.
@@ -6661,6 +7053,7 @@ async fn fetch_page_html_raw_base(
         only_html,
         first_byte_timeout,
         first_byte_jitter,
+        engine,
     )
     .await
     {
@@ -6674,6 +7067,7 @@ async fn fetch_page_html_raw_base(
                     only_html,
                     first_byte_timeout,
                     first_byte_jitter,
+                    engine,
                 )
                 .await
                 {
@@ -6699,6 +7093,7 @@ async fn fetch_page_html_raw_base(
                         only_html,
                         first_byte_timeout,
                         first_byte_jitter,
+                        engine,
                     )
                     .await
                     {
@@ -6717,6 +7112,7 @@ async fn fetch_page_html_raw_base(
                         only_html,
                         first_byte_timeout,
                         first_byte_jitter,
+                        engine,
                     )
                     .await
                     {
@@ -6738,7 +7134,7 @@ async fn fetch_page_html_raw_base(
 
 /// Perform a network request to a resource extracting all content streaming.
 pub async fn fetch_page_html_raw(target_url: &str, client: &Client) -> PageResponse {
-    fetch_page_html_raw_base(target_url, client, false, None, None).await
+    fetch_page_html_raw_base(target_url, client, false, None, None, None).await
 }
 
 /// Same as [`fetch_page_html_raw`] but arms the HTTP first-byte
@@ -6761,6 +7157,7 @@ pub async fn fetch_page_html_raw_with_watchdog(
         false,
         first_byte_timeout,
         first_byte_jitter,
+        None,
     )
     .await
 }
@@ -6839,6 +7236,7 @@ pub async fn fetch_page_html_raw_cached(
     cache_options: Option<CacheOptions>,
     cache_policy: &Option<BasicCachePolicy>,
     cache_namespace: Option<&str>,
+    engine: Option<crate::fetch_engine::EngineFetchCtx<'_>>,
 ) -> PageResponse {
     let duration = if cfg!(feature = "time") {
         Some(tokio::time::Instant::now())
@@ -6859,7 +7257,7 @@ pub async fn fetch_page_html_raw_cached(
         return response;
     }
 
-    let response = fetch_page_html_raw_base(target_url, client, false, None, None).await;
+    let response = fetch_page_html_raw_base(target_url, client, false, None, None, engine).await;
 
     // On a cache miss, publish the fresh HTTP response to the shared
     // remote cache worker when the runtime flag is on. Best-effort —
@@ -6882,7 +7280,7 @@ pub async fn fetch_page_html_raw_cached(
 
 /// Perform a network request to a resource extracting all content streaming.
 pub async fn fetch_page_html_raw_only_html(target_url: &str, client: &Client) -> PageResponse {
-    fetch_page_html_raw_base(target_url, client, false, None, None).await
+    fetch_page_html_raw_base(target_url, client, false, None, None, None).await
 }
 
 /// Fetch a single page via the spider.cloud REST API.
@@ -7061,7 +7459,7 @@ pub async fn fetch_page_html_with_fallback(
     spider_cloud: &crate::configuration::SpiderCloudConfig,
     only_html: bool,
 ) -> PageResponse {
-    let resp = fetch_page_html_raw_base(target_url, client, only_html, None, None).await;
+    let resp = fetch_page_html_raw_base(target_url, client, only_html, None, None, None).await;
 
     let body_bytes = resp.content.as_deref();
     let should_fallback = spider_cloud.should_fallback(resp.status_code.as_u16(), body_bytes);
@@ -10777,9 +11175,15 @@ error was encountered while trying to use an ErrorDocument to handle the request
         let cache_options = Some(CacheOptions::Yes);
         let cache_policy = None;
 
-        let page =
-            fetch_page_html_raw_cached(target_url, &client, cache_options, &cache_policy, None)
-                .await;
+        let page = fetch_page_html_raw_cached(
+            target_url,
+            &client,
+            cache_options,
+            &cache_policy,
+            None,
+            None,
+        )
+        .await;
         assert_eq!(page.status_code, StatusCode::OK);
 
         let content = String::from_utf8_lossy(
@@ -10866,9 +11270,15 @@ error was encountered while trying to use an ErrorDocument to handle the request
         let cache_policy = None;
 
         let cached_start = tokio::time::Instant::now();
-        let cached_page =
-            fetch_page_html_raw_cached(&target_url, &client, cache_options, &cache_policy, None)
-                .await;
+        let cached_page = fetch_page_html_raw_cached(
+            &target_url,
+            &client,
+            cache_options,
+            &cache_policy,
+            None,
+            None,
+        )
+        .await;
         let cached_duration = cached_start.elapsed();
 
         assert_eq!(cached_page.status_code, StatusCode::OK);

--- a/spider/src/website.rs
+++ b/spider/src/website.rs
@@ -1319,6 +1319,14 @@ pub struct Website {
     /// Default `None` means today's behavior verbatim — every existing
     /// fetch site still runs spider's reqwest path.
     pub remote_fetcher: Option<crate::fetcher::SharedRemoteFetcher>,
+    /// Optional in-process HTTP fetch engine. Unlike [`Self::remote_fetcher`]
+    /// (which replaces the whole crawl loop), this replaces only the inner
+    /// body-fetch step on the HTTP crawl paths, so spider's retry / cache /
+    /// watchdog / hedge machinery still wraps the engine call. Opt-in via
+    /// [`Self::with_fetch_engine`]; consulted per URL through
+    /// [`crate::fetch_engine::HttpFetchEngine::should_fetch`]. Default `None`
+    /// keeps every fetch site on spider's reqwest path.
+    pub fetch_engine: Option<crate::fetch_engine::SharedHttpFetchEngine>,
     /// Optional per-request proxy routing strategy.
     ///
     /// When set together with [`crate::configuration::Configuration::proxies_by_kind`],
@@ -4195,6 +4203,20 @@ impl Website {
 
             let mut domain_parsed = self.domain_parsed.take();
 
+            // In-process fetch engine for the seed fetch (raw path). Cloned
+            // into owned locals so the borrow never conflicts with the
+            // `&mut self` field access on the fetch calls below.
+            let engine_ref = self.fetch_engine.clone();
+            let engine_cfg = engine_ref
+                .as_ref()
+                .map(|_| std::sync::Arc::new((*self.configuration).clone()));
+            let engine_ctx = match (engine_ref.as_ref(), engine_cfg.as_ref()) {
+                (Some(e), Some(cfg)) => {
+                    Some(crate::fetch_engine::EngineFetchCtx::new(e, cfg.as_ref()))
+                }
+                _ => None,
+            };
+
             #[allow(unused_mut)]
             let mut page = if let Some(mut seeded_page) = self.build_seed_page() {
                 // Extract links and metadata from seeded HTML content if not binary
@@ -4221,7 +4243,7 @@ impl Website {
                 }
                 seeded_page
             } else {
-                Page::new_page_streaming(
+                Page::new_page_streaming_engine(
                     url,
                     client,
                     false,
@@ -4234,6 +4256,7 @@ impl Website {
                     &mut self.domain_parsed,
                     &mut links_pages,
                     self.configuration.auto_http_first_byte_args(),
+                    engine_ctx,
                 )
                 .await
             };
@@ -4315,7 +4338,7 @@ impl Website {
                     let mut domain_parsed_clone = self.domain_parsed.clone();
 
                     if let Err(elapsed) = tokio::time::timeout(BACKOFF_MAX_DURATION, async {
-                        page = Page::new_page_streaming(
+                        page = Page::new_page_streaming_engine(
                             url,
                             client,
                             false,
@@ -4328,6 +4351,7 @@ impl Website {
                             &mut domain_parsed_clone,
                             &mut links_pages,
                             (None, None),
+                            engine_ctx,
                         )
                         .await;
                     })
@@ -4342,7 +4366,7 @@ impl Website {
 
                     self.domain_parsed = domain_parsed_clone;
                 } else {
-                    page = Page::new_page_streaming(
+                    page = Page::new_page_streaming_engine(
                         url,
                         client,
                         false,
@@ -4355,6 +4379,7 @@ impl Website {
                         &mut self.domain_parsed,
                         &mut links_pages,
                         self.configuration.auto_http_first_byte_args(),
+                        engine_ctx,
                     )
                     .await;
                 }
@@ -6108,6 +6133,18 @@ impl Website {
 
         self.configuration.configure_allowlist();
 
+        // In-process fetch engine for the seed fetches (raw glob path).
+        let engine_ref = self.fetch_engine.clone();
+        let engine_cfg = engine_ref
+            .as_ref()
+            .map(|_| std::sync::Arc::new((*self.configuration).clone()));
+        let engine_ctx = match (engine_ref.as_ref(), engine_cfg.as_ref()) {
+            (Some(e), Some(cfg)) => {
+                Some(crate::fetch_engine::EngineFetchCtx::new(e, cfg.as_ref()))
+            }
+            _ => None,
+        };
+
         for url in expanded {
             #[cfg(feature = "regex")]
             let url_ref: &CaseInsensitiveString = &url;
@@ -6135,7 +6172,7 @@ impl Website {
 
                 let mut domain_parsed = self.domain_parsed.take();
 
-                let mut page = Page::new_page_streaming(
+                let mut page = Page::new_page_streaming_engine(
                     &url,
                     client,
                     false,
@@ -6148,6 +6185,7 @@ impl Website {
                     &mut self.domain_parsed,
                     &mut links_pages,
                     self.configuration.auto_http_first_byte_args(),
+                    engine_ctx,
                 )
                 .await;
 
@@ -6221,7 +6259,7 @@ impl Website {
                         let mut domain_parsed_clone = self.domain_parsed.clone();
 
                         if let Err(elapsed) = tokio::time::timeout(BACKOFF_MAX_DURATION, async {
-                            page = Page::new_page_streaming(
+                            page = Page::new_page_streaming_engine(
                                 &url,
                                 client,
                                 false,
@@ -6234,6 +6272,7 @@ impl Website {
                                 &mut domain_parsed_clone,
                                 &mut links_pages,
                                 (None, None),
+                                engine_ctx,
                             )
                             .await;
                         })
@@ -6246,7 +6285,7 @@ impl Website {
 
                         self.domain_parsed = domain_parsed_clone;
                     } else {
-                        page = Page::new_page_streaming(
+                        page = Page::new_page_streaming_engine(
                             &url,
                             client,
                             false,
@@ -6259,6 +6298,7 @@ impl Website {
                             &mut self.domain_parsed,
                             &mut links_pages,
                             self.configuration.auto_http_first_byte_args(),
+                            engine_ctx,
                         )
                         .await;
                     }
@@ -7966,6 +8006,14 @@ impl Website {
 
             let mut set: JoinSet<(HashSet<CaseInsensitiveString>, Option<u64>)> = JoinSet::new();
             let retry_strategy_ref = self.retry_strategy.clone();
+            // In-process HTTP fetch engine, cloned once per crawl; the full
+            // config is snapshotted into an `Arc` only when an engine is
+            // installed, so each spawned task borrows it to build a
+            // per-task `EngineFetchCtx`.
+            let engine_ref = self.fetch_engine.clone();
+            let engine_cfg = engine_ref
+                .as_ref()
+                .map(|_| std::sync::Arc::new((*self.configuration).clone()));
 
             #[cfg(feature = "auto_throttle")]
             let auto_throttle_arc = self.auto_throttle.clone();
@@ -8095,7 +8143,18 @@ impl Website {
                                 let pb_semaphore_ref = pb_semaphore_raw.clone();
                                 #[allow(unused_variables)]
                                 let retry_strategy_ref = retry_strategy_ref.clone();
+                                let engine_ref = engine_ref.clone();
+                                let engine_cfg = engine_cfg.clone();
                                 spawn_set("page_fetch", &mut set, async move {
+                                    // Per-task borrow-only engine context from the cloned
+                                    // handle + config snapshot (both task-local).
+                                    let engine_ctx = match (engine_ref.as_ref(), engine_cfg.as_ref())
+                                    {
+                                        (Some(e), Some(cfg)) => Some(
+                                            crate::fetch_engine::EngineFetchCtx::new(e, cfg.as_ref()),
+                                        ),
+                                        _ => None,
+                                    };
                                     let link_result = match &shared.9 {
                                         Some(cb) => cb(link, None),
                                         _ => (link, None),
@@ -8243,11 +8302,11 @@ impl Website {
                                                     let mut r_settings = shared.7;
                                                     r_settings.ssg_build = true;
                                                     let mut domain_parsed = None;
-                                                    let page = Page::new_page_streaming(
+                                                    let page = Page::new_page_streaming_engine(
                                                         target_url, primary_client, only_html,
                                                         &mut selectors, external_domains_caseless,
                                                         &r_settings, &mut links, None, &shared.8,
-                                                        &mut domain_parsed, &mut links_pages, (None, None)).await;
+                                                        &mut domain_parsed, &mut links_pages, (None, None), engine_ctx).await;
                                                     (page, links, links_pages)
                                                 };
 
@@ -8269,11 +8328,11 @@ impl Website {
                                                             let mut r_settings = shared.7;
                                                             r_settings.ssg_build = true;
                                                             let mut domain_parsed = None;
-                                                            let page = Page::new_page_streaming(
+                                                            let page = Page::new_page_streaming_engine(
                                                                 target_url, hedge_client, only_html,
                                                                 &mut selectors, external_domains_caseless,
                                                                 &r_settings, &mut links, None, &shared.8,
-                                                                &mut domain_parsed, &mut links_pages, (None, None)).await;
+                                                                &mut domain_parsed, &mut links_pages, (None, None), engine_ctx).await;
                                                             (page, links, links_pages)
                                                         };
 
@@ -8309,11 +8368,11 @@ impl Website {
                                                 let mut r_settings = shared.7;
                                                 r_settings.ssg_build = true;
                                                 let mut domain_parsed = None;
-                                                let page = Page::new_page_streaming(
+                                                let page = Page::new_page_streaming_engine(
                                                     target_url, primary_client, only_html,
                                                     &mut selectors, external_domains_caseless,
                                                     &r_settings, &mut links, None, &shared.8,
-                                                    &mut domain_parsed, &mut links_pages, (None, None)).await;
+                                                    &mut domain_parsed, &mut links_pages, (None, None), engine_ctx).await;
                                                 hedge_trk.record(fetch_start.elapsed());
                                                 if page.status_code.is_server_error() {
                                                     hedge_trk.record_error();
@@ -8334,11 +8393,11 @@ impl Website {
                                             let mut r_settings = shared.7;
                                             r_settings.ssg_build = true;
                                             let mut domain_parsed = None;
-                                            let page = Page::new_page_streaming(
+                                            let page = Page::new_page_streaming_engine(
                                                 target_url, client, only_html,
                                                 &mut selectors, external_domains_caseless,
                                                 &r_settings, &mut links, None, &shared.8,
-                                                &mut domain_parsed, &mut links_pages, (None, None)).await;
+                                                &mut domain_parsed, &mut links_pages, (None, None), engine_ctx).await;
                                             hedge_trk.record(fetch_start.elapsed());
                                             if page.status_code.is_server_error() {
                                                 hedge_trk.record_error();
@@ -8382,11 +8441,11 @@ impl Website {
                                                     let mut r_settings = shared.7;
                                                     r_settings.ssg_build = true;
                                                     let mut domain_parsed = None;
-                                                    let page = Page::new_page_streaming(
+                                                    let page = Page::new_page_streaming_engine(
                                                         target_url, client, only_html,
                                                         &mut selectors, external_domains_caseless,
                                                         &r_settings, &mut links, None, &shared.8,
-                                                        &mut domain_parsed, &mut links_pages, (None, None)).await;
+                                                        &mut domain_parsed, &mut links_pages, (None, None), engine_ctx).await;
                                                     (page, links, links_pages)
                                                 };
                                                 tokio::pin!(primary_fut);
@@ -8459,7 +8518,7 @@ impl Website {
                                             let mut r_settings = shared.7;
                                             r_settings.ssg_build = true;
                                             let mut domain_parsed = None;
-                                            let page = Page::new_page_streaming(
+                                            let page = Page::new_page_streaming_engine(
                                                 target_url,
                                                 client, only_html,
                                                 &mut relative_selectors,
@@ -8469,7 +8528,7 @@ impl Website {
                                                 None,
                                                 &shared.8,
                                                 &mut domain_parsed,
-                                                &mut links_pages, (None, None)).await;
+                                                &mut links_pages, (None, None), engine_ctx).await;
                                             (page, links, links_pages)
                                         }
                                     };
@@ -8529,7 +8588,7 @@ impl Website {
                                                 let mut domain_parsed = None;
                                                 let mut retry_r_settings = shared.7;
                                                 retry_r_settings.ssg_build = true;
-                                                let next_page = Page::new_page_streaming(
+                                                let next_page = Page::new_page_streaming_engine(
                                                     target_url,
                                                     retry_client, only_html,
                                                     &mut shared.1.clone(),
@@ -8539,7 +8598,7 @@ impl Website {
                                                     None,
                                                     &shared.8,
                                                     &mut domain_parsed,
-                                                    &mut links_pages, (None, None)).await;
+                                                    &mut links_pages, (None, None), engine_ctx).await;
 
                                                 page = next_page;
 
@@ -8552,7 +8611,7 @@ impl Website {
                                             let mut domain_parsed = None;
                                             let mut retry_r_settings = shared.7;
                                             retry_r_settings.ssg_build = true;
-                                            page = Page::new_page_streaming(
+                                            page = Page::new_page_streaming_engine(
                                                 target_url,
                                                 retry_client,
                                                 only_html,
@@ -8563,7 +8622,7 @@ impl Website {
                                                 None,
                                                 &shared.8,
                                                 &mut domain_parsed,
-                                                &mut links_pages, (None, None)).await;
+                                                &mut links_pages, (None, None), engine_ctx).await;
                                         }
 
                                         // Stamp profile key from strategy.
@@ -11385,6 +11444,14 @@ impl Website {
 
             let add_external = !self.configuration.external_domains_caseless.is_empty();
             let retry_strategy_ref = self.retry_strategy.clone();
+            // In-process HTTP fetch engine, cloned once per crawl. The full
+            // configuration is snapshotted into an `Arc` only when an engine
+            // is installed, so each spawned task can borrow it to build an
+            // `EngineFetchCtx` for parity with the reqwest path.
+            let engine_ref = self.fetch_engine.clone();
+            let engine_cfg = engine_ref
+                .as_ref()
+                .map(|_| std::sync::Arc::new((*self.configuration).clone()));
             let mut exceeded_budget = false;
             let concurrency = throttle.is_zero();
 
@@ -11451,19 +11518,31 @@ impl Website {
                                 let shared = shared.clone();
                                 let on_should_crawl_callback = on_should_crawl_callback.clone();
                                 let retry_strategy_ref = retry_strategy_ref.clone();
+                                let engine_ref = engine_ref.clone();
+                                let engine_cfg = engine_cfg.clone();
                                 spawn_set("page_fetch", &mut set, async move {
+                                    // Build a borrow-only engine context for this task from
+                                    // the cloned handle + config snapshot (both task-local).
+                                    let engine_ctx = match (engine_ref.as_ref(), engine_cfg.as_ref())
+                                    {
+                                        (Some(e), Some(cfg)) => Some(
+                                            crate::fetch_engine::EngineFetchCtx::new(e, cfg.as_ref()),
+                                        ),
+                                        _ => None,
+                                    };
                                     let link_result = match &shared.7 {
                                         Some(cb) => cb(link, None),
                                         _ => (link, None),
                                     };
 
                                     let url = link_result.0.as_ref();
-                                    let mut page = Page::new_page_with_cache(
+                                    let mut page = Page::new_page_with_cache_engine(
                                         url,
                                         &shared.0,
                                         shared.4.get_cache_options(),
                                         &shared.4.cache_policy,
                                         shared.4.cache_namespace_str(),
+                                        engine_ctx,
                                     )
                                     .await;
 
@@ -11529,12 +11608,13 @@ impl Website {
                                                     .await;
                                                     chrome_attempted = true;
                                                 } else {
-                                                    let next_page = Page::new_page_with_cache(
+                                                    let next_page = Page::new_page_with_cache_engine(
                                                         url,
                                                         &shared.0,
                                                         shared.4.get_cache_options(),
                                                         &shared.4.cache_policy,
                                             shared.4.cache_namespace_str(),
+                                                        engine_ctx,
                                                     )
                                                     .await;
 
@@ -11558,12 +11638,13 @@ impl Website {
                                             .await;
                                             chrome_attempted = true;
                                         } else {
-                                            page = Page::new_page_with_cache(
+                                            page = Page::new_page_with_cache_engine(
                                                     url,
                                                     &shared.0,
                                                     shared.4.get_cache_options(),
                                                     &shared.4.cache_policy,
                                             shared.4.cache_namespace_str(),
+                                                    engine_ctx,
                                                 )
                                                     .await;
                                         }
@@ -13465,6 +13546,33 @@ impl Website {
         fetcher: crate::fetcher::SharedRemoteFetcher,
     ) -> &mut Self {
         self.remote_fetcher = Some(fetcher);
+        self
+    }
+
+    /// Install an in-process HTTP fetch engine
+    /// ([`crate::fetch_engine::HttpFetchEngine`]). On the HTTP crawl paths
+    /// spider will call the engine in place of its inner
+    /// `client.get(url).send()` for every URL where
+    /// [`should_fetch`](crate::fetch_engine::HttpFetchEngine::should_fetch)
+    /// returns `true`, while keeping its retry / cache / watchdog / hedge
+    /// machinery wrapped around the call. Zero-cost and behavior-identical
+    /// when unset.
+    pub fn with_fetch_engine<F: crate::fetch_engine::HttpFetchEngine>(
+        &mut self,
+        engine: F,
+    ) -> &mut Self {
+        self.fetch_engine = Some(std::sync::Arc::new(engine));
+        self
+    }
+
+    /// Install a pre-`Arc`d fetch engine — handy when sharing one engine
+    /// across multiple `Website` instances (the common case, since the
+    /// engine's own state / connection pool is shared).
+    pub fn with_shared_fetch_engine(
+        &mut self,
+        engine: crate::fetch_engine::SharedHttpFetchEngine,
+    ) -> &mut Self {
+        self.fetch_engine = Some(engine);
         self
     }
 

--- a/spider/src/website.rs
+++ b/spider/src/website.rs
@@ -6139,9 +6139,7 @@ impl Website {
             .as_ref()
             .map(|_| std::sync::Arc::new((*self.configuration).clone()));
         let engine_ctx = match (engine_ref.as_ref(), engine_cfg.as_ref()) {
-            (Some(e), Some(cfg)) => {
-                Some(crate::fetch_engine::EngineFetchCtx::new(e, cfg.as_ref()))
-            }
+            (Some(e), Some(cfg)) => Some(crate::fetch_engine::EngineFetchCtx::new(e, cfg.as_ref())),
             _ => None,
         };
 

--- a/spider/tests/fetch_engine_offline.rs
+++ b/spider/tests/fetch_engine_offline.rs
@@ -1,0 +1,115 @@
+//! End-to-end offline test for the in-process `HttpFetchEngine` seam.
+//!
+//! A mock engine intercepts every fetch (`should_fetch` accepts all URLs),
+//! so `crawl_raw` runs with zero network I/O. This proves the raw-path
+//! wiring reaches the engine, that spider builds a `Page` from the
+//! engine's `EngineResponse`, and — the key Point B parity check — that
+//! link extraction runs on the engine-served HTML so the crawl discovers
+//! and follows links exactly as it would on the reqwest path.
+
+use spider::fetch_engine::{EngineError, EngineRequest, EngineResponse, HttpFetchEngine};
+use spider::website::Website;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+const SEED: &str = "https://engine.test/";
+const CHILD: &str = "https://engine.test/child";
+
+struct MockEngine {
+    hits: Arc<AtomicUsize>,
+}
+
+#[async_trait::async_trait]
+impl HttpFetchEngine for MockEngine {
+    async fn fetch(&self, req: EngineRequest<'_>) -> Result<EngineResponse, EngineError> {
+        self.hits.fetch_add(1, Ordering::SeqCst);
+
+        // Seed links to CHILD; everything else is a leaf. Same body shape
+        // keeps the crawl bounded by the link graph.
+        let body = if req.url.starts_with(CHILD) {
+            "<html><head><title>leaf</title></head><body>leaf</body></html>".to_string()
+        } else {
+            format!(r#"<html><head><title>seed</title></head><body><a href="{CHILD}">child</a></body></html>"#)
+        };
+
+        let mut headers = reqwest::header::HeaderMap::new();
+        headers.insert(
+            reqwest::header::CONTENT_TYPE,
+            "text/html; charset=utf-8".parse().unwrap(),
+        );
+
+        Ok(EngineResponse {
+            status_code: reqwest::StatusCode::OK,
+            final_url: Some(req.url.to_string()),
+            headers,
+            body: body.into_bytes(),
+            served: true,
+            ..Default::default()
+        })
+    }
+}
+
+#[tokio::test]
+async fn engine_serves_raw_crawl_and_extracts_links() {
+    let hits = Arc::new(AtomicUsize::new(0));
+
+    let mut website = Website::new(SEED);
+    website
+        .with_fetch_engine(MockEngine { hits: hits.clone() })
+        .with_respect_robots_txt(false)
+        .with_limit(10);
+
+    website.crawl_raw().await;
+
+    // The engine served every fetch (no network). Two hits means the seed
+    // was fetched AND the child link — discovered by extracting links from
+    // the engine-served HTML — was followed. One hit would mean link
+    // extraction on the engine path failed.
+    assert!(
+        hits.load(Ordering::SeqCst) >= 2,
+        "engine should have served the seed and the extracted child (hits={})",
+        hits.load(Ordering::SeqCst)
+    );
+
+    // Both URLs were visited via the engine path.
+    let links = website.get_links();
+    let has_child = links.iter().any(|l| l.as_ref() == CHILD);
+    assert!(
+        has_child,
+        "child link should have been extracted from engine HTML and visited: {:?}",
+        links.iter().map(|l| l.as_ref().to_string()).collect::<Vec<_>>()
+    );
+}
+
+/// When `should_fetch` declines a URL, spider must fall through to its
+/// normal (reqwest) path — the engine is not consulted for the body.
+#[tokio::test]
+async fn engine_declines_falls_through() {
+    struct Declining {
+        hits: Arc<AtomicUsize>,
+    }
+    #[async_trait::async_trait]
+    impl HttpFetchEngine for Declining {
+        async fn fetch(&self, _req: EngineRequest<'_>) -> Result<EngineResponse, EngineError> {
+            self.hits.fetch_add(1, Ordering::SeqCst);
+            Ok(EngineResponse::default())
+        }
+        fn should_fetch(&self, _url: &str) -> bool {
+            false
+        }
+    }
+
+    let hits = Arc::new(AtomicUsize::new(0));
+    let mut website = Website::new("https://nonexistent.invalid/");
+    website
+        .with_fetch_engine(Declining { hits: hits.clone() })
+        .with_respect_robots_txt(false)
+        .with_limit(1);
+    website.crawl_raw().await;
+
+    assert_eq!(
+        hits.load(Ordering::SeqCst),
+        0,
+        "engine must not be consulted when should_fetch returns false"
+    );
+}

--- a/spider/tests/fetch_engine_offline.rs
+++ b/spider/tests/fetch_engine_offline.rs
@@ -29,7 +29,9 @@ impl HttpFetchEngine for MockEngine {
         let body = if req.url.starts_with(CHILD) {
             "<html><head><title>leaf</title></head><body>leaf</body></html>".to_string()
         } else {
-            format!(r#"<html><head><title>seed</title></head><body><a href="{CHILD}">child</a></body></html>"#)
+            format!(
+                r#"<html><head><title>seed</title></head><body><a href="{CHILD}">child</a></body></html>"#
+            )
         };
 
         let mut headers = reqwest::header::HeaderMap::new();
@@ -77,7 +79,10 @@ async fn engine_serves_raw_crawl_and_extracts_links() {
     assert!(
         has_child,
         "child link should have been extracted from engine HTML and visited: {:?}",
-        links.iter().map(|l| l.as_ref().to_string()).collect::<Vec<_>>()
+        links
+            .iter()
+            .map(|l| l.as_ref().to_string())
+            .collect::<Vec<_>>()
     );
 }
 


### PR DESCRIPTION
Generic, provider-neutral fetch-engine hook that replaces only spider's innermost body-fetch step while keeping the surrounding retry / cache / first-byte-watchdog / hedge machinery wrapped around it — so an alternate in-process transport gets full behavior parity by construction (distinct from `RemoteFetcher`, which short-circuits the whole crawl loop).

## What
- New `fetch_engine` module: `HttpFetchEngine` trait (`fetch` + per-URL `should_fetch`), `EngineRequest` / `EngineResponse` / `EngineError` (error categories map onto spider's synthetic 52x codes), `SharedHttpFetchEngine`, `EngineFetchCtx`.
- `Website::fetch_engine` field + `with_fetch_engine` / `with_shared_fetch_engine` (ungated like `RemoteFetcher`; runtime opt-in via the `Option`, byte-identical when unset).
- Engine branches in `fetch_page_html_raw_base` (smart path, incl. TLS scheme-flip/strip-www ladder) and `new_page_streaming` (raw path via new `new_page_streaming_engine`, mirroring inline link-extraction). Shared `handle_engine_response_bytes[_writer]` + `build_engine_error_page_response` reuse the reqwest caps/utf8/anti-bot/NXDOMAIN logic.

## Tests
Offline integration test drives `crawl_raw` through a mock engine (link extraction + `should_fetch` fall-through); unit tests cover error->status mapping. Verified compiling across default / lean / `wreq` / `glob`+`parallel_backends`+`hedge`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)