### PR TITLE
chore(meta): tracked spider.cloud/crates homepage on published crates

### DIFF
--- a/spider/Cargo.toml
+++ b/spider/Cargo.toml
@@ -9,6 +9,7 @@ keywords = ["crawler", "spider", "scraper"]
 categories = ["web-programming", "command-line-utilities"]
 license = "MIT"
 documentation = "https://docs.rs/spider"
+homepage = "https://spider.cloud/crates"
 edition = "2021"
 
 [badges]

--- a/spider_agent/Cargo.toml
+++ b/spider_agent/Cargo.toml
@@ -9,6 +9,7 @@ keywords = ["agent", "llm", "automation", "web", "search"]
 categories = ["web-programming", "asynchronous"]
 license = "MIT"
 documentation = "https://docs.rs/spider_agent"
+homepage = "https://spider.cloud/crates"
 edition = "2021"
 
 [badges]

--- a/spider_agent_html/Cargo.toml
+++ b/spider_agent_html/Cargo.toml
@@ -9,6 +9,7 @@ keywords = ["html", "cleaning", "web", "scraping", "agent"]
 categories = ["web-programming", "text-processing"]
 license = "MIT"
 documentation = "https://docs.rs/spider_agent_html"
+homepage = "https://spider.cloud/crates"
 edition = "2021"
 
 [badges]

--- a/spider_agent_types/Cargo.toml
+++ b/spider_agent_types/Cargo.toml
@@ -9,6 +9,7 @@ keywords = ["agent", "llm", "automation", "web", "types"]
 categories = ["web-programming", "data-structures"]
 license = "MIT"
 documentation = "https://docs.rs/spider_agent_types"
+homepage = "https://spider.cloud/crates"
 edition = "2021"
 
 [badges]

--- a/spider_cli/Cargo.toml
+++ b/spider_cli/Cargo.toml
@@ -9,6 +9,7 @@ keywords = ["crawler", "spider", "spider_cli"]
 categories = ["web-programming", "command-line-utilities"]
 license = "MIT"
 documentation = "https://docs.rs/spider"
+homepage = "https://spider.cloud/crates"
 include = ["src/*", "LICENSE", "README.md"]
 edition = "2021"
 resolver = "2"

--- a/spider_mcp/Cargo.toml
+++ b/spider_mcp/Cargo.toml
@@ -9,6 +9,7 @@ keywords = ["crawler", "spider", "mcp", "scraper"]
 categories = ["web-programming", "command-line-utilities"]
 license = "MIT"
 documentation = "https://docs.rs/spider_mcp"
+homepage = "https://spider.cloud/crates"
 include = ["src/*", "LICENSE", "README.md"]
 edition = "2021"
 resolver = "2"

--- a/spider_utils/Cargo.toml
+++ b/spider_utils/Cargo.toml
@@ -9,6 +9,7 @@ keywords = ["crawler", "spider"]
 categories = ["web-programming", "command-line-utilities"]
 license = "MIT"
 documentation = "https://docs.rs/spider_utils"
+homepage = "https://spider.cloud/crates"
 edition = "2021"
 
 [dependencies]

--- a/spider_worker/Cargo.toml
+++ b/spider_worker/Cargo.toml
@@ -9,6 +9,7 @@ keywords = ["crawler", "spider", "spider_cli"]
 categories = ["web-programming"]
 license = "MIT"
 documentation = "https://docs.rs/spider"
+homepage = "https://spider.cloud/crates"
 include = ["src/*", "LICENSE", "README.md"]
 edition = "2021"
 resolver = "2"


### PR DESCRIPTION
Adds `homepage = "https://spider.cloud/crates"` to the `[package]` block of the 8 published workspace crates (`spider`, `spider_cli`, `spider_utils`, `spider_agent`, `spider_agent_html`, `spider_agent_types`, `spider_worker`, `spider_mcp`).

`spider.cloud/crates` is the 302 tracking redirect defined in the frontend `vercel.json` (`utm_source=crates.io`, `utm_medium=registry`, `utm_campaign=spider_rs`, `utm_content=homepage-link`). Setting it as each crate's `homepage` makes the crates.io "Homepage" link attribute traffic into the OSS/GitHub growth panel (backend endpoint `GET /v1/data/admin/oss-traffic`, added in spider-cloud-backend#122).

Companion to the repo **About** links already set (`/github`, `/github/py`, `/github/clients`, `/github/mcp`). Metadata-only; no code changes. Takes effect on the next crates.io publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)