### PR TITLE
fix(budget): ignore empty path segments in depth/budget checks

### DIFF
--- a/spider/src/website.rs
+++ b/spider/src/website.rs
@@ -2078,7 +2078,9 @@ impl Website {
 
         if let Some(segments) = get_path_from_url(link)
             .strip_prefix('/')
-            .map(|remainder| remainder.split('/'))
+            // Skip empty segments so a trailing slash ("/a/b/") counts the same
+            // depth as "/a/b" instead of an extra phantom level.
+            .map(|remainder| remainder.split('/').filter(|segment| !segment.is_empty()))
         {
             let mut depth: usize = 0;
 
@@ -2143,7 +2145,11 @@ impl Website {
                 if !skip_paths && !exceeded_wild_budget {
                     let path_segments = get_path_from_url(link)
                         .strip_prefix('/')
-                        .map(|remainder| remainder.split('/'));
+                        // Skip empty segments so a trailing slash does not inflate
+                        // the depth count or re-check the final budget key.
+                        .map(|remainder| {
+                            remainder.split('/').filter(|segment| !segment.is_empty())
+                        });
 
                     match path_segments {
                         Some(segments) => {
@@ -18134,4 +18140,29 @@ async fn shutdown_conserves_semaphore_permits() {
         PERMITS,
         "JoinSet::shutdown() must restore all owned permits without add_permits"
     );
+}
+
+#[test]
+fn depth_limit_ignores_trailing_slash() {
+    let mut website: Website = Website::new("https://example.com");
+    website.configuration.depth = 2;
+    website.configuration.depth_distance = 2;
+
+    // A trailing slash must not add a phantom depth level: "/a/b/" is the same
+    // logical depth as "/a/b" and both are within the depth-2 budget.
+    for url in ["https://example.com/a/b", "https://example.com/a/b/"] {
+        assert!(
+            !website.is_over_depth(&url.into()),
+            "{url} is within depth 2 and must be crawled"
+        );
+    }
+
+    // The fix must not over-permit: genuinely deeper paths are still dropped,
+    // with or without a trailing slash.
+    for url in ["https://example.com/a/b/c", "https://example.com/a/b/c/"] {
+        assert!(
+            website.is_over_depth(&url.into()),
+            "{url} exceeds depth 2 and must be dropped"
+        );
+    }
 }


### PR DESCRIPTION
### Summary

Depth- and budget-limited crawls silently drop directory URLs that end in a
trailing slash. `https://site/a/b/` is treated as one level deeper than
`https://site/a/b`, so the same page is crawled without the slash and dropped
with it — at every depth boundary.

### Details

`is_over_inner_depth_budget` and `is_over_inner_budget` compute depth by
splitting the path on `/` and counting segments:

```rust
get_path_from_url(link)
    .strip_prefix('/')
    .map(|remainder| remainder.split('/'))
```

A trailing slash yields an empty final segment — `"a/b/".split('/')` produces
`["a", "b", ""]` — so `/a/b/` counts as depth 3 while `/a/b` counts as depth 2.
With `with_depth(2)`, `/a/b` is crawled and `/a/b/` is dropped, even though they
are the same directory at the same logical depth. Directory-style URLs ending in
`/` are extremely common, so this drops real pages.

The same empty segment also affects `is_over_inner_budget`: after the last real
segment decrements its budget key, the trailing empty segment re-checks the same
key and can mark the URL over-budget a visit early.

### Fix

Filter out empty segments before counting, in both functions:

```rust
.map(|remainder| remainder.split('/').filter(|segment| !segment.is_empty()))
```

Now `/a/b/` and `/a/b` count identically. Empty segments never contributed a
meaningful path component or budget key, so nothing else changes.

### Test

Added `depth_limit_ignores_trailing_slash`, which fails on the current code (the
trailing-slash URL is dropped) and passes after the fix. It also asserts the fix
does not over-permit: genuinely deeper paths (`/a/b/c`, `/a/b/c/`) are still
dropped.

Verified locally:

- `cargo fmt --all -- --check`
- `cargo clippy -p spider -- -D warnings`
- `cargo test -p spider` — all passing, including the existing budget tests
