### PR TITLE
fix(redirect): block reserved IPv4/IPv6 ranges in the SSRF guard

### DIFF
--- a/spider/src/website.rs
+++ b/spider/src/website.rs
@@ -2604,8 +2604,9 @@ impl Website {
     }
 
     /// SSRF guard for redirect targets. Refuses hops into loopback,
-    /// link-local (cloud-metadata), private, broadcast, or unspecified
-    /// addresses, and non-HTTP(S) schemes.
+    /// link-local (cloud-metadata), private, unique-local, broadcast,
+    /// unspecified or otherwise reserved addresses, and non-HTTP(S)
+    /// schemes.
     ///
     /// The configured seed URL is fetched directly and never passes
     /// through the redirect policy, so an intentionally-internal start
@@ -2614,7 +2615,29 @@ impl Website {
     /// attacker-controlled page uses (cf. GHSA-8v6v-g4rh-jmcm). Operates
     /// on the already-parsed `Url` so it adds no allocation per hop.
     fn is_ssrf_redirect(url: &Url) -> bool {
-        use std::net::IpAddr;
+        use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+        fn is_internal_v4(v4: Ipv4Addr) -> bool {
+            v4.is_loopback()
+                || v4.is_private()
+                || v4.is_link_local()
+                || v4.is_unspecified()
+                || v4.is_broadcast()
+                // RFC 1122 reserves all of 0.0.0.0/8 as "this network";
+                // `is_unspecified` only matches 0.0.0.0 itself.
+                || v4.octets()[0] == 0
+        }
+
+        fn is_internal_v6(v6: Ipv6Addr) -> bool {
+            v6.is_loopback()
+                || v6.is_unspecified()
+                // fc00::/7 is the IPv6 side of RFC 1918, and where the
+                // cloud metadata service answers (fd00:ec2::254).
+                || v6.is_unique_local()
+                // fe80::/10 is the IPv6 side of 169.254.0.0/16.
+                || v6.is_unicast_link_local()
+                || v6.to_ipv4_mapped().is_some_and(is_internal_v4)
+        }
 
         let scheme = url.scheme();
         if scheme != "http" && scheme != "https" {
@@ -2645,26 +2668,8 @@ impl Website {
             .and_then(|h| h.strip_suffix(']'))
             .unwrap_or(host);
         match ip_host.parse::<IpAddr>() {
-            Ok(IpAddr::V4(v4)) => {
-                v4.is_loopback()
-                    || v4.is_private()
-                    || v4.is_link_local()
-                    || v4.is_unspecified()
-                    || v4.is_broadcast()
-            }
-            Ok(IpAddr::V6(v6)) => {
-                v6.is_loopback()
-                    || v6.is_unspecified()
-                    || v6
-                        .to_ipv4_mapped()
-                        .map(|v4| {
-                            v4.is_loopback()
-                                || v4.is_private()
-                                || v4.is_link_local()
-                                || v4.is_unspecified()
-                        })
-                        .unwrap_or(false)
-            }
+            Ok(IpAddr::V4(v4)) => is_internal_v4(v4),
+            Ok(IpAddr::V6(v6)) => is_internal_v6(v6),
             _ => false,
         }
     }
@@ -15876,9 +15881,10 @@ async fn test_cache_shortcircuit_crawl_smart() {
 mod tests {
 
     /// Redirect SSRF guard must refuse loopback, link-local (cloud
-    /// metadata), private, IPv6 / IPv4-mapped, localhost variants and
-    /// non-HTTP schemes, while still allowing ordinary public hosts so
-    /// legitimate cross-site redirects keep working.
+    /// metadata), private, unique-local, reserved, IPv6 / IPv4-mapped,
+    /// localhost variants and non-HTTP schemes, while still allowing
+    /// ordinary public hosts so legitimate cross-site redirects keep
+    /// working.
     #[test]
     fn test_is_ssrf_redirect_blocks_internal() {
         use url::Url;
@@ -15887,6 +15893,9 @@ mod tests {
             "http://localhost/admin",
             "http://sub.localhost/",
             "http://0.0.0.0/",
+            // 0.0.0.0/8 past the unspecified address itself.
+            "http://0.0.0.1/",
+            "http://0.1.2.3/",
             "http://169.254.169.254/latest/meta-data/",
             "http://metadata.google.internal/",
             "http://10.0.0.5/",
@@ -15894,6 +15903,11 @@ mod tests {
             "http://172.16.0.1/",
             "http://[::1]/",
             "http://[::ffff:127.0.0.1]/",
+            "http://[::ffff:255.255.255.255]/",
+            "http://[fc00::1]/",
+            // IPv6 endpoint of the cloud metadata service.
+            "http://[fd00:ec2::254]/latest/meta-data/",
+            "http://[fe80::1]/",
             "ftp://127.0.0.1/",
         ] {
             assert!(
@@ -15905,6 +15919,7 @@ mod tests {
             "http://example.com/",
             "https://api.github.com/repos",
             "http://93.184.216.34/",
+            "http://[2606:4700:4700::1111]/",
         ] {
             assert!(
                 !super::Website::is_ssrf_redirect(&Url::parse(allowed).unwrap()),


### PR DESCRIPTION
`Website::is_ssrf_redirect` screens every redirect hop for internal address space, and it blocks reserved ranges whole: `is_private()` covers all of RFC 1918, `is_link_local()` all of `169.254.0.0/16`. Three places broke that pattern.

### The IPv6 branch had no native internal ranges

It covered `::1`, `::` and IPv4-mapped forms, so `fc00::/7` (unique local) and `fe80::/10` (link local) went through. `fc00::/7` is what an IPv6 network uses where an IPv4 network uses RFC 1918, and `fe80::/10` is the counterpart of `169.254.0.0/16`, both of which the IPv4 branch blocks.

The case that motivated the patch: AWS documents `http://[fd00:ec2::254]/latest/meta-data/` as the IPv6 endpoint of the instance metadata service, and `fd00:ec2::254` sits inside `fc00::/7`. The guard names `169.254.169.254`, `metadata.google.internal` and `metadata.goog` explicitly, so it was refusing one address of a credential store and following the other.

### `0.0.0.0/8` was blocked one address at a time

`Ipv4Addr::is_unspecified()` is an equality test against `0.0.0.0` rather than a range check, so `http://0.0.0.1/` passed. RFC 1122 reserves the whole block as "this network", never valid as a destination.

On exploitability, measured rather than assumed: on Linux `0.0.0.0` routes to `lo`, while `0.0.0.1` and `0.1.2.3` route to the default gateway and time out against a listener on `127.0.0.1`. So the rest of the block is not a way to reach localhost, and `0.0.0.0` itself was already blocked twice. What makes it worth closing is that these are reserved destinations a crawler has no reason to dial, that the outcome varies by OS and by anything in the path including the proxies spider supports, and that comparable filters (Python's `ipaddress`, Node's `private-ip`) list the block rather than the address.

### The IPv4-mapped closure omitted `is_broadcast()`

`255.255.255.255` was refused and `::ffff:255.255.255.255` was not. That one disappears now that both families share a predicate, which is why the patch is a small refactor instead of three separate conditions.

## Not changed

- **The seed URL stays unscreened.** It never passes through the redirect policy, so an intentionally-internal start URL keeps working. That split is the threat model the docstring already states, and the patch stays inside it.
- **The string prefilter is untouched**, including the now-redundant `host == "0.0.0.0"`.
- **Alternative IPv4 spellings** (`127.1`, `0177.0.0.1`, `2130706433`) need nothing: the `url` crate normalizes them to dotted-quad before the guard sees the host.

## Known limitation

A hostname that resolves to an internal address still passes, since this is a check on the literal host. Closing that means resolving before the connect and pinning the resolved address for the life of the connection, which is a custom connector rather than a string predicate, so it stays out of this PR. Can be tracked in a separate issue if that is useful.

`spider_worker`'s `target_host_blocked` carries a thinner copy of this logic (loopback and unspecified only on the IPv6 side, no `to_ipv4_mapped`). Left alone here, since it is opt-in behind an environment variable and lives in another crate.

## Tests

`test_is_ssrf_redirect_blocks_internal` gains six blocked cases, each of which fails before the patch and passes after:

```
0.0.0.1  0.1.2.3  [fc00::1]  [fd00:ec2::254]  [fe80::1]  [::ffff:255.255.255.255]
```

`[2606:4700:4700::1111]` joins the allowed list, so a regression that refuses public IPv6 would fail the test.

```sh
cargo test -p spider --lib test_is_ssrf_redirect_blocks_internal
```

Run locally along with `cargo check --workspace`, `cargo fmt --check` and `cargo clippy -p spider`. The workflow runs targeted tests rather than the whole suite, so this one does not run in CI.
